### PR TITLE
knowing skull event override

### DIFF
--- a/src/main/java/downfall/downfallMod.java
+++ b/src/main/java/downfall/downfallMod.java
@@ -486,7 +486,7 @@ public class downfallMod implements
                 //Event Spawn Condition//
                 .spawnCondition(() -> evilMode)
                 //Event ID to Override//
-                .overrideEvent(KnowingSkull.ID)
+                .overrideEvent(com.megacrit.cardcrawl.events.city.KnowingSkull.ID)
                 //Event Type//
                 .eventType(EventUtils.EventType.FULL_REPLACE)
                 .create());


### PR DESCRIPTION
was not using correct ID, instead referencing the relic with the same name as the event