### PR TITLE
Fix charbosses not dying to Judgement

### DIFF
--- a/src/main/java/charbosses/bosses/AbstractCharBoss.java
+++ b/src/main/java/charbosses/bosses/AbstractCharBoss.java
@@ -1032,7 +1032,7 @@ public abstract class AbstractCharBoss extends AbstractMonster {
         }
         this.lastDamageTaken = Math.min(damageAmount, this.currentHealth);
         final boolean probablyInstantKill = this.currentHealth == 0;
-        if (damageAmount > 0) {
+        if (damageAmount > 0 || probablyInstantKill) {
             for (final AbstractPower p : this.powers) {
                 damageAmount = p.onLoseHp(damageAmount);
             }


### PR DESCRIPTION
This outer "damageAmount > 0" is meant to skip most of the logic
when an attack is fully blocked. Judgement sets the boss HP to zero and
then does a zero damage hit, skipping the logic. So, also run the logic
if the boss HP is zero.