### PR TITLE
misc fixes

### DIFF
--- a/src/main/java/guardian/relics/ModeShifterPlus.java
+++ b/src/main/java/guardian/relics/ModeShifterPlus.java
@@ -29,7 +29,7 @@ public class ModeShifterPlus extends CustomRelic {
 
     public void atBattleStartPreDraw() {
         this.flash();
-        AbstractDungeon.actionManager.addToBottom(new GainBlockAction(AbstractDungeon.player, AbstractDungeon.player, 8));
+        AbstractDungeon.actionManager.addToBottom(new GainBlockAction(AbstractDungeon.player, AbstractDungeon.player, 10));
         AbstractDungeon.actionManager.addToBottom(new ChangeStanceAction(DefensiveMode.STANCE_ID));
         AbstractDungeon.actionManager.addToBottom(new ApplyPowerAction(AbstractDungeon.player, AbstractDungeon.player, new DontLeaveDefensiveModePower(AbstractDungeon.player, 3), 3));
     }

--- a/src/main/java/slimebound/cards/DuplicatedForm.java
+++ b/src/main/java/slimebound/cards/DuplicatedForm.java
@@ -104,8 +104,7 @@ public class DuplicatedForm extends AbstractSlimeboundCard {
 
         int stack = 1;
         //if (upgraded) stack++;
-        AbstractDungeon.actionManager.addToBottom(new ApplyPowerAction(p, p, new DuplicatedFormEnergyPower(p, p, stack), stack));
-
+        if (upgraded) AbstractDungeon.actionManager.addToBottom(new ApplyPowerAction(p, p, new DuplicatedFormEnergyPower(p, p, stack), stack));
 
         int MaxHPActuallyLost = baseHealthCost;
         if (AbstractDungeon.player.maxHealth <= baseHealthCost) {

--- a/src/main/resources/champResources/localization/eng/PowerStrings.json
+++ b/src/main/resources/champResources/localization/eng/PowerStrings.json
@@ -103,17 +103,17 @@
   "champ:StrikeOfGeniusPower": {
     "NAME": "Strike of Genius",
     "DESCRIPTIONS": [
-      "At the start of your turn, add a random card that Enters a Stance to your hand. It costs #b0 until played and Exhausts.",
+      "At the start of your turn, add a random card containing \"Strike\" to your hand. It costs #b0 until played and Exhausts.",
       "At the start of your turn, add #b",
-      " random cards that Enter a Stance to your hand. They cost #b0 until played and Exhausts."
+      " random cards containing \"Strike\" to your hand. They cost #b0 until played and Exhaust."
     ]
   },
   "champ:StrikeOfGeniusUpgradedPower": {
     "NAME": "Strike of Genius+",
     "DESCRIPTIONS": [
-      "At the start of your turn, add a random #yupgraded card that Enters a Stance to your hand. It costs #b0 until played.",
+      "At the start of your turn, add a random #yupgraded card containing \"Strike\" to your hand. It costs #b0 until played and Exhausts.",
       "At the start of your turn, add #b",
-      " random #yupgraded cards that Enter a Stance to your hand. They cost #b0 until played."
+      " random #yupgraded cards containing \"Strike\" to your hand. They cost #b0 until played and Exhaust."
     ]
   },
   "champ:DefensiveStylePower": {


### PR DESCRIPTION
fixed strike of genius's power text still referring to stances rather than strikes

fixed guardian gear (upgraded guardian starter relic) giving you 8 block instead of 10 block

fixed **un**upgraded duplicated form giving you +1 energy per turn.