### PR TITLE
champ's "enchant" cards prompt fix

### DIFF
--- a/src/main/resources/champResources/localization/eng/UIStrings.json
+++ b/src/main/resources/champResources/localization/eng/UIStrings.json
@@ -28,9 +28,9 @@
   },
   "champ:EnchantUI": {
     "TEXT": [
-      "Choose a card to cost 0.",
-      "Choose a card to increase damage.",
-      "Choose a card to increase Block."
+      "cost 0.",
+      "increase damage.",
+      "increase Block."
     ]
   }
 }


### PR DESCRIPTION
Seems like the prompt automatically starts with "Choose a card to", so all three of the Enchant cards needed that part of their string removed. "Choose a card to Choose a card to cost 0." was what we were seeing.