### PR TITLE
Update CouncilsJustice.java

### DIFF
--- a/src/main/java/theHexaghost/cards/CouncilsJustice.java
+++ b/src/main/java/theHexaghost/cards/CouncilsJustice.java
@@ -19,7 +19,7 @@ public class CouncilsJustice extends AbstractHexaCard {
     public CouncilsJustice() {
         super(ID, 1, CardType.ATTACK, CardRarity.SPECIAL, CardTarget.ENEMY, CardColor.COLORLESS);
         baseDamage = DAMAGE;
-        baseMagicNumber = 3;
+        baseMagicNumber = magicNumber = 3;
         exhaust = true;
         isEthereal = true;
         cardsToPreview = new Apparition();


### PR DESCRIPTION
Council's Justice wasn't setting magicNumber properly (only baseMagicNumber) so it was initially -1. This fixes it, and it's working properly now.