### PR TITLE
Fixing null pointer exception in SlowingSlime

### DIFF
--- a/src/main/java/slimebound/orbs/SlowingSlime.java
+++ b/src/main/java/slimebound/orbs/SlowingSlime.java
@@ -71,8 +71,10 @@ public class SlowingSlime
 
     public void cleanUpVFX() {
         if(!reskinContent.slimeReskinAnimation){
-        this.stopwatch.finish();
-        this.antennae.finish();
+            if (this.stopwatch != null) {
+                this.stopwatch.finish();
+                this.antennae.finish();
+            }
         }
     }
 


### PR DESCRIPTION
Fixing null pointer exception for when vfx cleanup happens before postSpawnEffects