### PR TITLE
Ban Step Through from Unknown cards

### DIFF
--- a/src/main/java/theHexaghost/cards/StepThrough.java
+++ b/src/main/java/theHexaghost/cards/StepThrough.java
@@ -21,7 +21,8 @@ public class StepThrough extends AbstractHexaCard {
     public StepThrough() {
         super(ID, 1, CardType.ATTACK, CardRarity.UNCOMMON, CardTarget.ENEMY);
         baseDamage = DAMAGE;
-        tags.add(HexaMod.GHOSTWHEELCARD);
+        this.tags.add(HexaMod.GHOSTWHEELCARD);
+        this.tags.add(SneckoMod.BANNEDFORSNECKO);
     }
 
     public void use(AbstractPlayer p, AbstractMonster m) {


### PR DESCRIPTION
Without the ghostwheel effect, it's worse than a Strike. Forked Flame is also banned and does 1 more damage.