### PR TITLE
Run locking potions for champ, snecko, and hexaghost

### DIFF
--- a/src/main/java/champ/ChampMod.java
+++ b/src/main/java/champ/ChampMod.java
@@ -19,6 +19,7 @@ import champ.relics.*;
 import champ.stances.AbstractChampStance;
 import champ.util.CardFilter;
 import champ.util.CoolVariable;
+import downfall.patches.BanSharedContentPatch;
 import downfall.util.TextureLoader;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.Texture;
@@ -272,6 +273,8 @@ public class ChampMod implements
         BaseMod.addPotion(OpenerPotion.class, Color.TEAL, Color.GREEN, Color.FOREST, OpenerPotion.POTION_ID, ChampChar.Enums.THE_CHAMP);
         BaseMod.addPotion(TechPotion.class, Color.BLUE, Color.PURPLE, Color.MAROON, TechPotion.POTION_ID, ChampChar.Enums.THE_CHAMP);
         BaseMod.addPotion(UltimateStancePotion.class, Color.PURPLE, Color.PURPLE, Color.MAROON, UltimateStancePotion.POTION_ID, ChampChar.Enums.THE_CHAMP);
+
+        BanSharedContentPatch.registerRunLockedPotion(ChampChar.Enums.THE_CHAMP, CounterstrikePotion.POTION_ID);
 
         if (Loader.isModLoaded("widepotions")) {
             WidePotionsMod.whitelistSimplePotion(CounterstrikePotion.POTION_ID);

--- a/src/main/java/downfall/patches/BanSharedContentPatch.java
+++ b/src/main/java/downfall/patches/BanSharedContentPatch.java
@@ -15,6 +15,7 @@ import com.megacrit.cardcrawl.helpers.PotionHelper;
 import com.megacrit.cardcrawl.relics.Ectoplasm;
 import downfall.cards.curses.*;
 import downfall.downfallMod;
+import downfall.events.HeartEvent;
 import downfall.relics.Hecktoplasm;
 import expansioncontent.actions.RandomCardWithTagAction;
 import expansioncontent.cards.*;
@@ -42,7 +43,17 @@ import theHexaghost.relics.BolsterEngine;
 import theHexaghost.relics.CandleOfCauterizing;
 import theHexaghost.relics.Sixitude;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 public class BanSharedContentPatch {
+    private static Map<AbstractPlayer.PlayerClass, List<String>> runLockedPotions = new HashMap<>();
+
+    public static void registerRunLockedPotion(AbstractPlayer.PlayerClass playerClass, String potionId) {
+        runLockedPotions.computeIfAbsent(playerClass, _ignore -> new ArrayList<>()).add(potionId);
+    }
 
     @SpirePatch(
             clz = AbstractDungeon.class,
@@ -172,6 +183,15 @@ public class BanSharedContentPatch {
                 PotionHelper.potions.remove(CounterstrikePotion.POTION_ID);
                 PotionHelper.potions.remove(BurnAndBuffPotion.POTION_ID);
             }
+            // Ban shared potions from other classes if you haven't played as that class before
+            runLockedPotions.forEach((playerClass, potionIds) ->{
+                // Shared potions will never be banned from their base class
+                if (chosenClass!=playerClass) {
+                    if(!HeartEvent.hasPlayedRun(playerClass)) {
+                        PotionHelper.potions.removeAll(potionIds);
+                    }
+                }
+            });
         }
     }
 }

--- a/src/main/java/sneckomod/SneckoMod.java
+++ b/src/main/java/sneckomod/SneckoMod.java
@@ -27,6 +27,7 @@ import com.megacrit.cardcrawl.helpers.CardLibrary;
 import downfall.cards.OctoChoiceCard;
 import downfall.downfallMod;
 import downfall.events.Serpent_Evil;
+import downfall.patches.BanSharedContentPatch;
 import downfall.util.CardIgnore;
 import downfall.util.TextureLoader;
 import expansioncontent.patches.CardColorEnumPatch;
@@ -343,6 +344,8 @@ public class SneckoMod implements
         BaseMod.addPotion(CheatPotion.class, Color.GRAY, Color.WHITE, Color.BLACK, CheatPotion.POTION_ID, TheSnecko.Enums.THE_SNECKO);
         BaseMod.addPotion(DiceRollPotion.class, Color.CYAN, Color.WHITE, Color.BLACK, DiceRollPotion.POTION_ID, TheSnecko.Enums.THE_SNECKO);
         BaseMod.addPotion(OffclassReductionPotion.class, Color.CYAN, Color.CORAL, Color.MAROON, OffclassReductionPotion.POTION_ID, TheSnecko.Enums.THE_SNECKO);
+
+        BanSharedContentPatch.registerRunLockedPotion(TheSnecko.Enums.THE_SNECKO, MuddlingPotion.POTION_ID);
 
         if (Loader.isModLoaded("widepotions")) {
             WidePotionsMod.whitelistSimplePotion(MuddlingPotion.POTION_ID);

--- a/src/main/java/theHexaghost/HexaMod.java
+++ b/src/main/java/theHexaghost/HexaMod.java
@@ -28,6 +28,7 @@ import com.megacrit.cardcrawl.rooms.AbstractRoom;
 import com.megacrit.cardcrawl.scenes.TheBottomScene;
 import com.megacrit.cardcrawl.vfx.scene.InteractableTorchEffect;
 import downfall.downfallMod;
+import downfall.patches.BanSharedContentPatch;
 import downfall.util.CardIgnore;
 import javassist.CtClass;
 import javassist.Modifier;
@@ -239,6 +240,8 @@ public class HexaMod implements
         BaseMod.addPotion(SoulburnPotion.class, Color.GRAY, Color.GRAY, Color.BLACK, SoulburnPotion.POTION_ID);
         BaseMod.addPotion(DoubleChargePotion.class, Color.BLUE, Color.PURPLE, Color.MAROON, DoubleChargePotion.POTION_ID, TheHexaghost.Enums.THE_SPIRIT);
         BaseMod.addPotion(InfernoChargePotion.class, Color.PURPLE, Color.PURPLE, Color.MAROON, InfernoChargePotion.POTION_ID, TheHexaghost.Enums.THE_SPIRIT);
+
+        BanSharedContentPatch.registerRunLockedPotion(TheHexaghost.Enums.THE_SPIRIT, SoulburnPotion.POTION_ID);
 
         if (Loader.isModLoaded("widepotions")) {
             WidePotionsMod.whitelistSimplePotion(EctoCoolerPotion.POTION_ID);


### PR DESCRIPTION
Run locks shared potions for Snecko, Hexaghost, and Champ, so unique mechanics don't appear before the characters are played