### PR TITLE
Fix Dupe Pot putting glitched copies of self-stasis cards in stasis

### DIFF
--- a/src/main/java/guardian/patches/SelfStasisPatch.java
+++ b/src/main/java/guardian/patches/SelfStasisPatch.java
@@ -38,7 +38,7 @@ public class SelfStasisPatch {
         @SpirePostfixPatch
         public static void awayItGoes(UseCardAction __instance, AbstractCard card, AbstractCreature target)
         {
-            if (card.hasTag(GuardianMod.SELFSTASIS) || card.hasTag(GuardianMod.SELFSTASISONCE))
+            if (!card.purgeOnUse && (card.hasTag(GuardianMod.SELFSTASIS) || card.hasTag(GuardianMod.SELFSTASISONCE)))
             {
                 card.tags.remove(GuardianMod.SELFSTASISONCE);
 


### PR DESCRIPTION
Fixes an issue where playing Duplication Pot followed by Charge Core results in this glitched stasis slot. Probably fixes the same issue with Necronomicon, Double Tap and similar.

![image](https://user-images.githubusercontent.com/307683/110618120-825ab100-813a-11eb-9f66-99bc68bd10cb.png)
