### PR TITLE
Fix Lucky Horseshoe giving unsuitable card rewards

### DIFF
--- a/src/main/java/sneckomod/util/ColorfulCardReward.java
+++ b/src/main/java/sneckomod/util/ColorfulCardReward.java
@@ -29,7 +29,7 @@ public class ColorfulCardReward extends CustomReward {
         ArrayList<AbstractCard> cardsList = new ArrayList<>();
         ArrayList<AbstractCard> listOfColoredCards = new ArrayList<>();
         for (AbstractCard q : CardLibrary.getAllCards()) {
-            if (q.color == myColor) {
+            if (q.color == myColor && q.rarity != AbstractCard.CardRarity.SPECIAL && !q.tags.contains(SneckoMod.BANNEDFORSNECKO)) {
                 listOfColoredCards.add(q);
             }
         }


### PR DESCRIPTION
Rewards no longer give SPECIAL rarity cards (cards generated in combat
and event rewards) and BANNEDFORSNECKO cards (ghostwheel cards and gems,
mostly).