### PR TITLE
Fix various issues with Seal of Approval and Lucky Horseshoe

### DIFF
--- a/src/main/java/sneckomod/patches/SnekCardPoolPatch.java
+++ b/src/main/java/sneckomod/patches/SnekCardPoolPatch.java
@@ -1,0 +1,23 @@
+package sneckomod.patches;
+
+import com.evacipated.cardcrawl.modthespire.lib.SpirePatch;
+import com.evacipated.cardcrawl.modthespire.lib.SpirePostfixPatch;
+import com.megacrit.cardcrawl.characters.AbstractPlayer;
+import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
+import sneckomod.relics.SneckoBoss;
+import sneckomod.relics.SneckoCommon;
+
+@SpirePatch(
+        clz = AbstractDungeon.class,
+        method = "initializeCardPools"
+
+)
+public class SnekCardPoolPatch {
+    @SpirePostfixPatch
+    public static void Postfix(AbstractDungeon __instance) {
+        AbstractPlayer player = __instance.player;
+        if(player.hasRelic(SneckoCommon.ID) || player.hasRelic(SneckoBoss.ID)) {
+            SneckoBoss.updateCardPools();
+        }
+    }
+}


### PR DESCRIPTION
Fix an issue where other char cards appear after changing acts or saving.
Fix an issue where Seal completely forgets the chosen char after exiting.
Ensure that Seal and Horseshoe always use the same char regardless of
pickup order.