### PR TITLE
Fix various crashes caused by Blank Card

### DIFF
--- a/src/main/java/sneckomod/relics/BlankCard.java
+++ b/src/main/java/sneckomod/relics/BlankCard.java
@@ -37,6 +37,7 @@ public class BlankCard extends CustomRelic {
 
             card2.freeToPlayOnce = true;
             card2.purgeOnUse = true;
+            card2.applyPowers();
 
             flash();
             AbstractDungeon.effectList.add(new ShowCardBrieflyEffect(card2.makeStatEquivalentCopy()));


### PR DESCRIPTION
For instance, Gremlin Dance crashing because it doesn't know which
gremlin is in front until applyPowers is called.