### PR TITLE
Fix several incorrect intents on boss cards, and other improvements

### DIFF
--- a/src/main/java/charbosses/bosses/AbstractCharBoss.java
+++ b/src/main/java/charbosses/bosses/AbstractCharBoss.java
@@ -382,6 +382,7 @@ public abstract class AbstractCharBoss extends AbstractMonster {
                     AbstractCharBoss.boss.hand.group = newHand;
 
                     AbstractCharBoss.boss.hand.refreshHandLayout();
+                    applyPowers();
                 }
             });
             addToBot(new WaitAction(0.2f));

--- a/src/main/java/charbosses/bosses/AbstractCharBoss.java
+++ b/src/main/java/charbosses/bosses/AbstractCharBoss.java
@@ -65,6 +65,8 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 
+import static charbosses.bosses.Ironclad.NewAge.ArchetypeAct3BlockNewAge.FORTIFICATION_AMOUNT;
+
 public abstract class AbstractCharBoss extends AbstractMonster {
 
     public static AbstractCharBoss boss;
@@ -503,7 +505,7 @@ public abstract class AbstractCharBoss extends AbstractMonster {
                 //Minion block checks for Act 3 Ironclad's Body Slams
                 if (c instanceof EnBodySlam) {
                     if (hasPower(BarricadePower.POWER_ID)) {
-                        c.manualCustomDamageModifier += 10;
+                        c.manualCustomDamageModifier += FORTIFICATION_AMOUNT;
                     }
                 }
 

--- a/src/main/java/charbosses/bosses/AbstractCharBoss.java
+++ b/src/main/java/charbosses/bosses/AbstractCharBoss.java
@@ -15,6 +15,7 @@ import charbosses.bosses.Merchant.CharBossMerchant;
 import charbosses.cards.AbstractBossCard;
 import charbosses.cards.EnemyCardGroup;
 import charbosses.cards.red.EnBodySlam;
+import charbosses.cards.red.EnSecondWind;
 import charbosses.core.EnemyEnergyManager;
 import charbosses.orbs.AbstractEnemyOrb;
 import charbosses.orbs.EnemyDark;
@@ -486,10 +487,15 @@ public abstract class AbstractCharBoss extends AbstractMonster {
 
                 //Block checks for Act 3 Ironclad's Body Slams
                 if (c.block > 0) {
+                    //Special case for Second Wind, always exhausts 2 wounds with Feel No Pain up
+                    int tmpBlock = c.block;
+                    if(c instanceof EnSecondWind) {
+                        tmpBlock = 2 * (c.block + 3);
+                    }
                     for (int j = i + 1; j < hand.size(); j++) {
                         AbstractBossCard c2 = (AbstractBossCard) hand.group.get(j);
                         if (c2 instanceof EnBodySlam) {
-                            c2.manualCustomDamageModifier += c.block;
+                            c2.manualCustomDamageModifier += tmpBlock;
                         }
                     }
                 }

--- a/src/main/java/charbosses/bosses/Ironclad/NewAge/ArchetypeAct3BlockNewAge.java
+++ b/src/main/java/charbosses/bosses/Ironclad/NewAge/ArchetypeAct3BlockNewAge.java
@@ -23,6 +23,7 @@ import com.megacrit.cardcrawl.powers.BarricadePower;
 import java.util.ArrayList;
 
 public class ArchetypeAct3BlockNewAge extends ArchetypeBaseIronclad {
+    public static final int FORTIFICATION_AMOUNT = 10;
 
     public ArchetypeAct3BlockNewAge() {
         super("IC_BLOCK_ARCHETYPE", "Block");

--- a/src/main/java/charbosses/bosses/Watcher/NewAge/ArchetypeAct2CalmNewAge.java
+++ b/src/main/java/charbosses/bosses/Watcher/NewAge/ArchetypeAct2CalmNewAge.java
@@ -88,6 +88,7 @@ public class ArchetypeAct2CalmNewAge extends ArchetypeBaseWatcher {
                     break;
                 case 4:
                     theVeryImportantBlasphemy.newPrio = -2;
+                    theVeryImportantBlasphemy.lockIntentValues = false;
                     theVeryImportantFlyingSleeves.newPrio = 0;
                     theVeryImportantFlyingSleeves.lockIntentValues = false;
                     AbstractBossCard c = new EnWish();

--- a/src/main/java/charbosses/cards/AbstractBossCard.java
+++ b/src/main/java/charbosses/cards/AbstractBossCard.java
@@ -97,7 +97,6 @@ public abstract class AbstractBossCard extends AbstractCard {
     private Texture intentBg;
     private PowerTip intentTip = new PowerTip();
     public int intentDmg;
-    public int intentBaseDmg;
     protected int intentMultiAmt;
     private Color intentColor = Color.WHITE.cpy();
     private float intentParticleTimer;
@@ -261,7 +260,6 @@ public abstract class AbstractBossCard extends AbstractCard {
         }
         this.damage = MathUtils.floor(tmp);
 
-        multiDamageCardCalculate();
         this.initializeDescription();
         if (this.intent != null) {
             if (!this.bossDarkened) {
@@ -306,51 +304,55 @@ public abstract class AbstractBossCard extends AbstractCard {
             this.owner = (AbstractCharBoss) mo;
         }
         if (mo != null) {
-            float tmp = (float) this.baseDamage;
-            for (final AbstractRelic r : this.owner.relics) {
-                tmp = r.atDamageModify(tmp, this);
-                if (this.baseDamage != (int) tmp) {
-                    this.isDamageModified = true;
-                }
-            }
-            for (final AbstractPower p : this.owner.powers) {
-                tmp = p.atDamageGive(tmp, this.damageTypeForTurn, this);
-            }
-            tmp = this.owner.stance.atDamageGive(tmp, this.damageTypeForTurn, this);
+            this.damage = MathUtils.floor(calculateDamage(mo, player, this.baseDamage));
+            this.intentDmg = MathUtils.floor(manualCustomDamageModifierMult * calculateDamage(mo, player, this.baseDamage + customIntentModifiedDamage() + manualCustomDamageModifier));
+        }
+        this.initializeDescription();
+    }
+
+    private float calculateDamage(AbstractMonster mo, AbstractPlayer player, float tmp) {
+        for (final AbstractRelic r : this.owner.relics) {
+            tmp = r.atDamageModify(tmp, this);
             if (this.baseDamage != (int) tmp) {
                 this.isDamageModified = true;
             }
-            if (mo == this.owner) {
-                for (final AbstractPower p : player.powers) {
-                    tmp = p.atDamageReceive(tmp, this.damageTypeForTurn, this);
-                }
-                tmp = player.stance.atDamageReceive(tmp, this.damageTypeForTurn);
-            } else {
-                for (final AbstractPower p : mo.powers) {
-                    tmp = p.atDamageReceive(tmp, this.damageTypeForTurn, this);
-                }
-            }
-            for (final AbstractPower p : this.owner.powers) {
-                tmp = p.atDamageFinalGive(tmp, this.damageTypeForTurn, this);
-            }
-            if (mo == this.owner) {
-                for (final AbstractPower p : player.powers) {
-                    tmp = p.atDamageFinalReceive(tmp, this.damageTypeForTurn, this);
-                }
-            } else {
-                for (final AbstractPower p : mo.powers) {
-                    tmp = p.atDamageFinalReceive(tmp, this.damageTypeForTurn, this);
-                }
-            }
-            if (tmp < 0.0f) {
-                tmp = 0.0f;
-            }
-            if (this.baseDamage != MathUtils.floor(tmp)) {
-                this.isDamageModified = true;
-            }
-            this.damage = MathUtils.floor(tmp);
         }
-        this.initializeDescription();
+        for (final AbstractPower p : this.owner.powers) {
+            tmp = p.atDamageGive(tmp, this.damageTypeForTurn, this);
+        }
+        tmp = this.owner.stance.atDamageGive(tmp, this.damageTypeForTurn, this);
+        if (this.baseDamage != (int) tmp) {
+            this.isDamageModified = true;
+        }
+        if (mo == this.owner) {
+            for (final AbstractPower p : player.powers) {
+                tmp = p.atDamageReceive(tmp, this.damageTypeForTurn, this);
+            }
+            tmp = player.stance.atDamageReceive(tmp, this.damageTypeForTurn);
+        } else {
+            for (final AbstractPower p : mo.powers) {
+                tmp = p.atDamageReceive(tmp, this.damageTypeForTurn, this);
+            }
+        }
+        for (final AbstractPower p : this.owner.powers) {
+            tmp = p.atDamageFinalGive(tmp, this.damageTypeForTurn, this);
+        }
+        if (mo == this.owner) {
+            for (final AbstractPower p : player.powers) {
+                tmp = p.atDamageFinalReceive(tmp, this.damageTypeForTurn, this);
+            }
+        } else {
+            for (final AbstractPower p : mo.powers) {
+                tmp = p.atDamageFinalReceive(tmp, this.damageTypeForTurn, this);
+            }
+        }
+        if (tmp < 0.0f) {
+            tmp = 0.0f;
+        }
+        if (this.baseDamage != MathUtils.floor(tmp)) {
+            this.isDamageModified = true;
+        }
+        return tmp;
     }
 
     public void triggerOnEndOfPlayerTurn() {
@@ -724,25 +726,13 @@ public abstract class AbstractBossCard extends AbstractCard {
         }
     }
 
-
-    public void multiDamageCardCalculate() {
-    }
-
     public void createIntent() {
         if (this.intent == null) return;
 
-
-        if (!lockIntentValues) multiDamageCardCalculate();
         //bossLighten();
         refreshIntentHbLocation();
         if (!intentActive) this.intentParticleTimer = 0.5F;
         if (!lockIntentValues) calculateCardDamage(null);
-        if (AbstractDungeon.player != null) {
-            if (AbstractDungeon.player.hasPower(IntangiblePower.POWER_ID)) {
-                this.intentBaseDmg = 1;
-            } else if (!lockIntentValues)
-                this.intentBaseDmg = this.intentDmg = Math.round(((this.damage + customIntentModifiedDamage() + manualCustomDamageModifier) * manualCustomDamageModifierMult));
-        }
 
         // //SlimeboundMod.logger.info(this.name + " intent being created: damage = " + this.intentDmg);
 
@@ -750,7 +740,6 @@ public abstract class AbstractBossCard extends AbstractCard {
         // //SlimeboundMod.logger.info(this.name + " intent being created: custom manual damage = " + manualCustomDamageModifier * manualCustomDamageModifierMult);
 
         if ((!lockIntentValues) && this.damage > -1) {
-            this.calculateCardDamage(null);
             if (this.isMultiDamage) {
                 this.intentMultiAmt = this.magicNumber;
             } else {
@@ -781,7 +770,6 @@ public abstract class AbstractBossCard extends AbstractCard {
             this.intentAlphaTarget = 0F;
             this.showIntent = false;
             this.intentParticleTimer = 0F;
-            this.intentBaseDmg = 0;
             this.tipIntent = null;
             //SlimeboundMod.logger.info(this.name + " intent destroyed.");
         }

--- a/src/main/java/charbosses/monsters/Fortification.java
+++ b/src/main/java/charbosses/monsters/Fortification.java
@@ -16,6 +16,8 @@ import com.megacrit.cardcrawl.powers.BarricadePower;
 import com.megacrit.cardcrawl.powers.DemonFormPower;
 import downfall.downfallMod;
 
+import static charbosses.bosses.Ironclad.NewAge.ArchetypeAct3BlockNewAge.FORTIFICATION_AMOUNT;
+
 public class Fortification extends AbstractMonster {
 
     public static final String ID = downfallMod.makeID("Fortification");
@@ -35,7 +37,7 @@ public class Fortification extends AbstractMonster {
     public void takeTurn() {
         if (AbstractCharBoss.boss != null) {
             if (!AbstractCharBoss.boss.isDead && !AbstractCharBoss.boss.isDying)
-            AbstractDungeon.actionManager.addToBottom(new GainBlockAction(AbstractCharBoss.boss, this, 10));
+            AbstractDungeon.actionManager.addToBottom(new GainBlockAction(AbstractCharBoss.boss, this, FORTIFICATION_AMOUNT));
             AbstractDungeon.actionManager.addToBottom(new WaitAction(0.1F));
             AbstractDungeon.actionManager.addToBottom(new WaitAction(0.1F));
         }

--- a/src/main/java/charbosses/powers/bossmechanicpowers/FakeOrRealPower.java
+++ b/src/main/java/charbosses/powers/bossmechanicpowers/FakeOrRealPower.java
@@ -55,6 +55,7 @@ public class FakeOrRealPower extends AbstractPower implements CloneablePowerInte
             for (AbstractMonster q : AbstractDungeon.getCurrRoom().monsters.monsters) {
                 if (q instanceof MirrorImageSilent) {
                     q.isDead = true;
+                    q.isDying = true;
                     AbstractDungeon.effectList.add(new SmallerSmokeBombEffect(q.hb.cX, q.hb.cY));
                 }
                 addToTop(new RemoveSpecificPowerAction(q, q, this.ID));

--- a/src/main/java/charbosses/powers/bossmechanicpowers/IroncladFortificationPower.java
+++ b/src/main/java/charbosses/powers/bossmechanicpowers/IroncladFortificationPower.java
@@ -27,7 +27,7 @@ public class IroncladFortificationPower extends AbstractBossMechanicPower {
     }
 
     public void updateDescription() {
-        this.description = DESC[0];
+        this.description = DESC[0] + amount + DESC[1];
     }
 
     static {

--- a/src/main/java/charbosses/powers/bossmechanicpowers/IroncladFortificationPower.java
+++ b/src/main/java/charbosses/powers/bossmechanicpowers/IroncladFortificationPower.java
@@ -10,6 +10,8 @@ import com.megacrit.cardcrawl.core.CardCrawlGame;
 import com.megacrit.cardcrawl.localization.PowerStrings;
 import com.megacrit.cardcrawl.powers.AbstractPower;
 
+import static charbosses.bosses.Ironclad.NewAge.ArchetypeAct3BlockNewAge.FORTIFICATION_AMOUNT;
+
 public class IroncladFortificationPower extends AbstractBossMechanicPower {
     public static final String POWER_ID = "downfall:IroncladFortificationPower";
     private static final PowerStrings powerStrings;
@@ -27,7 +29,7 @@ public class IroncladFortificationPower extends AbstractBossMechanicPower {
     }
 
     public void updateDescription() {
-        this.description = DESC[0] + amount + DESC[1];
+        this.description = DESC[0] + FORTIFICATION_AMOUNT + DESC[1];
     }
 
     static {

--- a/src/main/java/charbosses/relics/CBR_IncenseBurner.java
+++ b/src/main/java/charbosses/relics/CBR_IncenseBurner.java
@@ -35,9 +35,11 @@ public class CBR_IncenseBurner extends AbstractCharbossRelic {
         }
         if (this.counter == 6) {
             this.counter = 0;
-            this.flash();
+            this.beginLongPulse();
             this.addToBot(new RelicAboveCreatureAction(AbstractCharBoss.boss, this));
             this.addToBot(new ApplyPowerAction(AbstractCharBoss.boss, null, new BossIntangiblePower(AbstractCharBoss.boss, 1), 1));
+        } else {
+            this.stopPulse();
         }
     }
 

--- a/src/main/resources/downfallResources/localization/eng/PowerStrings.json
+++ b/src/main/resources/downfallResources/localization/eng/PowerStrings.json
@@ -192,7 +192,8 @@
   "downfall:IroncladFortificationPower": {
     "NAME": "Bastion",
     "DESCRIPTIONS": [
-      "Ironclad begins the fight with a Fortification, which will grant him #b15 Block each turn. NL When the Fortification has been destroyed, Ironclad loses Barricade, but gains #b5 Strength per turn."
+      "Ironclad begins the fight with a Fortification, which will grant him #b",
+      " Block each turn. NL When the Fortification has been destroyed, Ironclad loses Barricade, but gains #b5 Strength per turn."
     ]
   },
   "downfall:NeowBastion": {

--- a/src/main/resources/downfallResources/localization/zhs/PowerStrings.json
+++ b/src/main/resources/downfallResources/localization/zhs/PowerStrings.json
@@ -192,7 +192,8 @@
   "downfall:IroncladFortificationPower": {
     "NAME": "堡垒",
     "DESCRIPTIONS": [
-      " #y铁甲战士 构筑了 #y堡垒 。每回合 #y堡垒 将给予他 #b15 点 #y格挡 。 NL 当 #y堡垒 被摧毁时， #y铁甲战士 失去 #y壁垒 以及所有 #y格挡 ，但每回合将会获得 #b5 点 #y力量 。"
+      " #y铁甲战士 构筑了 #y堡垒 。每回合 #y堡垒 将给予他 #b",
+      " 点 #y格挡 。 NL 当 #y堡垒 被摧毁时， #y铁甲战士 失去 #y壁垒 以及所有 #y格挡 ，但每回合将会获得 #b5 点 #y力量 。"
     ]
   },
   "downfall:NeowBastion": {


### PR DESCRIPTION
Fixed Act 3 Ironclad's Body Slam sometimes having an incorrect intent
Fixed Act 2 Watcher's Flying Sleeves having an incorrect intent
Act 2 Watcher's Incense Burner pulsates whenever she is intangible
Fix Act 2 Silent's mirror image incorrectly taking hits from random-enemy attacks (Sword Boomerang, etc) after it is killed