### PR TITLE
Fix rare crash with Blank Card, Gremlin Dance, and starter relic

### DIFF
--- a/src/main/java/sneckomod/relics/BlankCard.java
+++ b/src/main/java/sneckomod/relics/BlankCard.java
@@ -2,6 +2,7 @@ package sneckomod.relics;
 
 import basemod.abstracts.CustomRelic;
 import com.badlogic.gdx.graphics.Texture;
+import com.megacrit.cardcrawl.actions.AbstractGameAction;
 import com.megacrit.cardcrawl.actions.utility.NewQueueCardAction;
 import com.megacrit.cardcrawl.cards.AbstractCard;
 import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
@@ -37,10 +38,17 @@ public class BlankCard extends CustomRelic {
 
             card2.freeToPlayOnce = true;
             card2.purgeOnUse = true;
-            card2.applyPowers();
 
             flash();
             AbstractDungeon.effectList.add(new ShowCardBrieflyEffect(card2.makeStatEquivalentCopy()));
+
+            AbstractDungeon.actionManager.addToBottom(new AbstractGameAction() {
+                @Override
+                public void update() {
+                    card2.applyPowers();
+                    isDone = true;
+                }
+            });
             AbstractDungeon.actionManager.addToBottom(new NewQueueCardAction(card2, m));
             this.activated = true;
         }


### PR DESCRIPTION
The crash occurs when the Gremlin starter relic swaps to the Mad
gremlin after the card is already in queue. Since the card in queue is
expecting to find a different gremlin in front, it crashes on Mad's
multi-damage attack because the multiDamage field is null. This isn't
obvious because the stack trace has incorrect line numbers within code
patched by basemod.

The fix of calling applyPowers was inspired by the code of the vanilla
card Havoc.

Rather than trying to find a different fix inside Gremlin Dance, this
fix ensures Blank Card will call applyPowers just before playing the
card, which hopefully avoids similar corner case crashes with
start-of-battle relics and other cards.