### PR TITLE
steel edge, donu/deca card crash, berserker's guide, frag grenade

### DIFF
--- a/src/main/java/automaton/powers/HardenedFormPower.java
+++ b/src/main/java/automaton/powers/HardenedFormPower.java
@@ -13,6 +13,7 @@ import com.megacrit.cardcrawl.core.Settings;
 import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
 import com.megacrit.cardcrawl.monsters.AbstractMonster;
 import com.megacrit.cardcrawl.powers.AbstractPower;
+import gremlin.actions.PseudoDamageRandomEnemyAction;
 
 public class HardenedFormPower extends AbstractAutomatonPower implements OnCompilePower {
     public static final String NAME = "HardenedForm";
@@ -44,7 +45,7 @@ public class HardenedFormPower extends AbstractAutomatonPower implements OnCompi
                 AbstractMonster m = AbstractDungeon.getMonsters().getRandomMonster(true);
                 if (m != null) {
                     addToTop(new GainBlockAction(owner, x));
-                    addToTop(new DamageAction(m, new DamageInfo(owner, x, DamageInfo.DamageType.THORNS), AbstractGameAction.AttackEffect.NONE));
+                    addToTop(new PseudoDamageRandomEnemyAction(m, new DamageInfo(owner, x, DamageInfo.DamageType.THORNS), AbstractGameAction.AttackEffect.NONE));
                     AbstractDungeon.actionManager.addToTop(new VFXAction(new com.megacrit.cardcrawl.vfx.combat.SmallLaserEffect(orbVFX.currentX + (50F * Settings.scale), orbVFX.currentY + (85F * Settings.scale), m.hb.cX, m.hb.cY), 0.1F));
                     AbstractDungeon.actionManager.addToTop(new SFXAction("ATTACK_MAGIC_BEAM_SHORT", 0.5F));
                 }

--- a/src/main/java/champ/cards/SteelEdge.java
+++ b/src/main/java/champ/cards/SteelEdge.java
@@ -1,6 +1,7 @@
 package champ.cards;
 
 import automaton.actions.EasyXCostAction;
+import champ.ChampChar;
 import com.megacrit.cardcrawl.actions.AbstractGameAction;
 import com.megacrit.cardcrawl.actions.common.DrawCardAction;
 import com.megacrit.cardcrawl.actions.common.GainEnergyAction;
@@ -28,6 +29,7 @@ public class SteelEdge extends AbstractChampCard {
     @Override
     public boolean canUse(AbstractPlayer p, AbstractMonster m) {
         if (!(bcombo()) && !dcombo()) {
+            this.cantUseMessage = ChampChar.characterStrings.TEXT[61];
             return false;
         }
         return super.canUse(p, m);

--- a/src/main/java/expansioncontent/cards/DecaShield.java
+++ b/src/main/java/expansioncontent/cards/DecaShield.java
@@ -74,11 +74,11 @@ public class DecaShield extends AbstractExpansionCard {
 
     public void upgrade() {
         if (!upgraded) {
-            if (cardsToPreview != null) cardsToPreview.upgrade();
             upgradeName();
             upgradeBlock(UPGRADE_BLOCK);
             rawDescription = UPGRADE_DESCRIPTION;
             initializeDescription();
+            if (cardsToPreview != null && !cardsToPreview.upgraded) cardsToPreview.upgrade();
         }
     }
 

--- a/src/main/java/expansioncontent/cards/PolyBeam.java
+++ b/src/main/java/expansioncontent/cards/PolyBeam.java
@@ -55,6 +55,9 @@ public class PolyBeam extends AbstractExpansionCard {
         atb(new SFXAction("ATTACK_MAGIC_BEAM_SHORT", 0.5F));
         atb(new VFXAction(new SmallLaserEffect(m.hb.cX, m.hb.cY, p.hb.cX, p.hb.cY), 0.3F));
         atb(new DamageAction(m, new DamageInfo(p, this.damage, this.damageTypeForTurn), AbstractGameAction.AttackEffect.FIRE));
+
+        atb(new SFXAction("ATTACK_MAGIC_BEAM_SHORT", 0.5F));
+        atb(new VFXAction(new SmallLaserEffect(m.hb.cX, m.hb.cY, p.hb.cX, p.hb.cY), 0.3F));
         atb(new DamageAction(m, new DamageInfo(p, this.damage, this.damageTypeForTurn), AbstractGameAction.AttackEffect.FIRE));
 
         atb(new AbstractGameAction() {
@@ -82,11 +85,11 @@ public class PolyBeam extends AbstractExpansionCard {
 
     public void upgrade() {
         if (!upgraded) {
-            if (cardsToPreview != null) cardsToPreview.upgrade();
             upgradeName();
             upgradeDamage(UPGRADE_DAMAGE);
             rawDescription = UPGRADE_DESCRIPTION;
             initializeDescription();
+            if (cardsToPreview != null && !cardsToPreview.upgraded) cardsToPreview.upgrade();
         }
     }
 

--- a/src/main/java/expansioncontent/powers/PretendHexWheelPower.java
+++ b/src/main/java/expansioncontent/powers/PretendHexWheelPower.java
@@ -17,6 +17,7 @@ import com.megacrit.cardcrawl.powers.AbstractPower;
 import com.megacrit.cardcrawl.vfx.combat.ScreenOnFireEffect;
 import expansioncontent.expansionContentMod;
 import downfall.util.TextureLoader;
+import gremlin.actions.PseudoDamageRandomEnemyAction;
 
 
 public class PretendHexWheelPower extends TwoAmountPower implements NonStackablePower {
@@ -54,7 +55,7 @@ public class PretendHexWheelPower extends TwoAmountPower implements NonStackable
                         isDone = true;
                         AbstractMonster m = AbstractDungeon.getRandomMonster();
                         if (m != null && !m.halfDead) {
-                            addToTop(new DamageAction(m, new DamageInfo(owner, amount2, DamageInfo.DamageType.THORNS), AttackEffect.FIRE));
+                            addToTop(new PseudoDamageRandomEnemyAction(m, new DamageInfo(owner, amount2, DamageInfo.DamageType.THORNS), AttackEffect.FIRE));
                         }
                     }
                 });

--- a/src/main/java/gremlin/actions/PseudoDamageRandomEnemyAction.java
+++ b/src/main/java/gremlin/actions/PseudoDamageRandomEnemyAction.java
@@ -1,0 +1,35 @@
+package gremlin.actions;
+
+import com.megacrit.cardcrawl.actions.AbstractGameAction;
+import com.megacrit.cardcrawl.actions.common.DamageAction;
+import com.megacrit.cardcrawl.cards.DamageInfo;
+import com.megacrit.cardcrawl.core.AbstractCreature;
+import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
+import gremlin.relics.FragmentationGrenade;
+
+public class PseudoDamageRandomEnemyAction extends AbstractGameAction {
+    private DamageInfo info;
+
+    public PseudoDamageRandomEnemyAction(AbstractCreature target, DamageInfo info, AttackEffect effect) {
+        this.target = target;
+        this.info = info;
+        this.actionType = AbstractGameAction.ActionType.DAMAGE;
+        this.attackEffect = effect;
+    }
+
+    public PseudoDamageRandomEnemyAction(AbstractCreature target, DamageInfo info) {
+        this(target, info, AttackEffect.NONE);
+    }
+
+    public void update() {
+        if (AbstractDungeon.player.hasRelic(FragmentationGrenade.ID)) {
+            AbstractDungeon.player.getRelic(FragmentationGrenade.ID).flash();
+            DamageInfo old = this.info;
+            this.info = new DamageInfo(old.owner, old.base + FragmentationGrenade.OOMPH, old.type);
+        }
+
+        this.addToTop(new DamageAction(this.target, this.info, this.attackEffect));
+
+        this.isDone = true;
+    }
+}

--- a/src/main/java/guardian/actions/PolyBeamAction.java
+++ b/src/main/java/guardian/actions/PolyBeamAction.java
@@ -16,6 +16,7 @@ import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
 import com.megacrit.cardcrawl.monsters.AbstractMonster;
 import com.megacrit.cardcrawl.vfx.combat.FlashAtkImgEffect;
 import com.megacrit.cardcrawl.vfx.combat.SmallLaserEffect;
+import gremlin.actions.PseudoDamageRandomEnemyAction;
 
 public class PolyBeamAction extends AbstractGameAction {
     private AbstractCard card;
@@ -38,7 +39,7 @@ public class PolyBeamAction extends AbstractGameAction {
             AbstractDungeon.topLevelEffects.add(new FlashAtkImgEffect(this.target.hb.cX, this.target.hb.cY, this.attackEffect));
 
             this.card.calculateCardDamage((AbstractMonster)this.target);
-            addToTop(new DamageAction(target, new DamageInfo(AbstractDungeon.player, this.card.damage, this.card.damageTypeForTurn)));
+            addToTop(new PseudoDamageRandomEnemyAction(target, new DamageInfo(AbstractDungeon.player, this.card.damage, this.card.damageTypeForTurn)));
         }
         this.isDone = true;
     }

--- a/src/main/java/guardian/cards/GatlingBeam.java
+++ b/src/main/java/guardian/cards/GatlingBeam.java
@@ -13,6 +13,7 @@ import com.megacrit.cardcrawl.core.CardCrawlGame;
 import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
 import com.megacrit.cardcrawl.localization.CardStrings;
 import com.megacrit.cardcrawl.monsters.AbstractMonster;
+import gremlin.actions.PseudoDamageRandomEnemyAction;
 import guardian.GuardianMod;
 import guardian.actions.PlaceActualCardIntoStasis;
 import guardian.orbs.StasisOrb;
@@ -120,7 +121,7 @@ public class GatlingBeam extends AbstractGuardianCard implements InStasisCard {
         {
             AbstractDungeon.actionManager.addToBottom(new SFXAction("ATTACK_MAGIC_BEAM_SHORT", 0.5F));
             AbstractDungeon.actionManager.addToBottom(new VFXAction(new SmallLaserEffectColored(m.hb.cX, m.hb.cY, AbstractDungeon.player.hb.cX, AbstractDungeon.player.hb.cY, Color.BLUE), 0.1F));
-            AbstractDungeon.actionManager.addToBottom(new DamageAction(m, new DamageInfo(AbstractDungeon.player, this.damage, DamageInfo.DamageType.NORMAL), AbstractGameAction.AttackEffect.FIRE));
+            AbstractDungeon.actionManager.addToBottom(new PseudoDamageRandomEnemyAction(m, new DamageInfo(AbstractDungeon.player, this.damage, DamageInfo.DamageType.NORMAL), AbstractGameAction.AttackEffect.FIRE));
         }
     }
 

--- a/src/main/java/guardian/relics/PocketSentry.java
+++ b/src/main/java/guardian/relics/PocketSentry.java
@@ -7,6 +7,7 @@ import com.megacrit.cardcrawl.actions.AbstractGameAction;
 import com.megacrit.cardcrawl.actions.animations.VFXAction;
 import com.megacrit.cardcrawl.actions.common.ApplyPowerAction;
 import com.megacrit.cardcrawl.actions.common.DamageAction;
+import com.megacrit.cardcrawl.actions.common.DamageRandomEnemyAction;
 import com.megacrit.cardcrawl.actions.utility.SFXAction;
 import com.megacrit.cardcrawl.cards.DamageInfo;
 import com.megacrit.cardcrawl.core.Settings;
@@ -17,6 +18,7 @@ import com.megacrit.cardcrawl.powers.WeakPower;
 import com.megacrit.cardcrawl.relics.AbstractRelic;
 import com.megacrit.cardcrawl.vfx.combat.ShockWaveEffect;
 import com.megacrit.cardcrawl.vfx.combat.SmallLaserEffect;
+import gremlin.actions.PseudoDamageRandomEnemyAction;
 import guardian.GuardianMod;
 
 public class PocketSentry extends CustomRelic {
@@ -50,7 +52,7 @@ public class PocketSentry extends CustomRelic {
                     isDone = true;
                     AbstractMonster m = AbstractDungeon.getMonsters().getRandomMonster(null,true,AbstractDungeon.relicRng);
                     if(m != null){
-                        AbstractDungeon.actionManager.addToTop(new DamageAction(m, new DamageInfo(AbstractDungeon.player, DAMAGE, DamageInfo.DamageType.THORNS), AbstractGameAction.AttackEffect.FIRE));
+                        AbstractDungeon.actionManager.addToTop(new PseudoDamageRandomEnemyAction(m, new DamageInfo(AbstractDungeon.player, DAMAGE, DamageInfo.DamageType.THORNS), AbstractGameAction.AttackEffect.FIRE));
                         AbstractDungeon.actionManager.addToTop(new VFXAction(new SmallLaserEffect(r.hb.cX - (5F * Settings.scale), r.hb.cY + (10F * Settings.scale), m.hb.cX, m.hb.cY), 0.3F));
                         AbstractDungeon.actionManager.addToTop(new SFXAction("ATTACK_MAGIC_BEAM_SHORT", 0.5F));
                     }

--- a/src/main/java/sneckomod/actions/BabySneckoAttackAction.java
+++ b/src/main/java/sneckomod/actions/BabySneckoAttackAction.java
@@ -5,6 +5,7 @@ import com.megacrit.cardcrawl.actions.common.DamageAction;
 import com.megacrit.cardcrawl.cards.DamageInfo;
 import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
 import com.megacrit.cardcrawl.monsters.AbstractMonster;
+import gremlin.actions.PseudoDamageRandomEnemyAction;
 import sneckomod.relics.BabySnecko;
 
 public class BabySneckoAttackAction extends AbstractGameAction {
@@ -20,7 +21,7 @@ public class BabySneckoAttackAction extends AbstractGameAction {
     public void update() {
         this.b.baby.state.setAnimation(0, "boop", false);
         this.b.baby.state.addAnimation(0, "idle", true, 0.0f);
-        AbstractDungeon.actionManager.addToBottom(new DamageAction(m, new DamageInfo(AbstractDungeon.player, 5, DamageInfo.DamageType.THORNS), AbstractGameAction.AttackEffect.BLUNT_LIGHT));
+        AbstractDungeon.actionManager.addToBottom(new PseudoDamageRandomEnemyAction(m, new DamageInfo(AbstractDungeon.player, 5, DamageInfo.DamageType.THORNS), AbstractGameAction.AttackEffect.BLUNT_LIGHT));
 
         this.isDone = true;
     }

--- a/src/main/java/theHexaghost/actions/EmbersAction.java
+++ b/src/main/java/theHexaghost/actions/EmbersAction.java
@@ -9,6 +9,7 @@ import com.megacrit.cardcrawl.core.Settings;
 import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
 import com.megacrit.cardcrawl.monsters.AbstractMonster;
 import downfall.actions.AbstractXAction;
+import gremlin.actions.PseudoDamageRandomEnemyAction;
 import theHexaghost.powers.BurnPower;
 
 public class EmbersAction extends AbstractXAction {
@@ -46,7 +47,7 @@ public class EmbersAction extends AbstractXAction {
                     isDone = true;
                     AbstractMonster m = AbstractDungeon.getRandomMonster();
                     addToTop(new ApplyPowerAction(m, p, new BurnPower(m, burn), burn));
-                    addToTop(new DamageAction(m, new DamageInfo(p, damage, damageTypeForTurn), AttackEffect.FIRE));
+                    addToTop(new PseudoDamageRandomEnemyAction(m, new DamageInfo(p, damage, damageTypeForTurn), AttackEffect.FIRE));
                 }
             });
         }

--- a/src/main/java/theHexaghost/cards/Incineration.java
+++ b/src/main/java/theHexaghost/cards/Incineration.java
@@ -6,6 +6,7 @@ import com.megacrit.cardcrawl.actions.common.DamageAction;
 import com.megacrit.cardcrawl.characters.AbstractPlayer;
 import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
 import com.megacrit.cardcrawl.monsters.AbstractMonster;
+import gremlin.actions.PseudoDamageRandomEnemyAction;
 import theHexaghost.powers.BurnPower;
 
 public class Incineration extends AbstractHexaCard {
@@ -34,7 +35,7 @@ public class Incineration extends AbstractHexaCard {
                 public void update() {
                     isDone = true;
                     AbstractMonster m = AbstractDungeon.getRandomMonster();
-                    addToTop(new DamageAction(m, makeInfo(), AttackEffect.FIRE));
+                    addToTop(new PseudoDamageRandomEnemyAction(m, makeInfo(), AttackEffect.FIRE));
                     addToTop(new ApplyPowerAction(m, p, new BurnPower(m, burn), burn));
                 }
             });

--- a/src/main/resources/champResources/localization/eng/RelicStrings.json
+++ b/src/main/resources/champResources/localization/eng/RelicStrings.json
@@ -24,7 +24,7 @@
     "NAME": "Berserker's Guide",
     "FLAVOR": "The text is illegible.",
     "DESCRIPTIONS": [
-      "Prevent the first #b10 HP you lose on your turn each combat."
+      "At the start of your turn, gain #b3 Vigor."
     ]
   },
   "champ:ChampionCrownUpgraded": {


### PR DESCRIPTION
fixed Steel Edge giving wrong "can't play" message
fixed donu/deca boss card crashing when upgraded during combat
fixed berserker's guide having an outdated and completely inaccurate description
fixed fragmentation grenade not working on a number of sources of random damage.