### PR TITLE
Burning Question, Strike from Beyond, Nightmare Vision, and text fixes

### DIFF
--- a/src/main/java/downfall/events/CursedFountain.java
+++ b/src/main/java/downfall/events/CursedFountain.java
@@ -75,6 +75,7 @@ public class CursedFountain extends AbstractImageEvent {
             case 0:
                 switch (buttonPressed) {
                     case 0:
+                        //bottle
                         this.imageEventText.updateBodyText(DESCRIPTIONS[2]);
                         this.imageEventText.updateDialogOption(0, OPTIONS[6], true);
                         AbstractDungeon.getCurrRoom().rewards.clear();
@@ -82,12 +83,14 @@ public class CursedFountain extends AbstractImageEvent {
                         AbstractDungeon.combatRewardScreen.open();
                         return;
                     case 1:
+                        //consume
                         this.imageEventText.updateBodyText(DESCRIPTIONS[1]);
                         this.imageEventText.updateDialogOption(1, OPTIONS[6], true);
                         AbstractDungeon.effectList.add(new RainingGoldEffect(this.goldAmt));
                         AbstractDungeon.player.gainGold(this.goldAmt);
                         return;
                     case 2:
+                        //drink
                         this.imageEventText.updateBodyText(DESCRIPTIONS[3]);
                         this.imageEventText.updateDialogOption(2, OPTIONS[6], true);
                         AbstractDungeon.player.heal(AbstractDungeon.player.maxHealth);

--- a/src/main/java/theHexaghost/actions/ChargeCurrentFlameAction.java
+++ b/src/main/java/theHexaghost/actions/ChargeCurrentFlameAction.java
@@ -10,9 +10,9 @@ public class ChargeCurrentFlameAction extends AbstractGameAction {
     }
 
     public void update() {
-    //    if (!HexaMod.renderFlames)
-     //       HexaMod.renderFlames = true;
+//        if (!HexaMod.renderFlames)
+//            HexaMod.renderFlames = true;
         isDone = true;
-        GhostflameHelper.activeGhostFlame.charge();
+        GhostflameHelper.activeGhostFlame.forceCharge();
     }
 }

--- a/src/main/java/theHexaghost/actions/RecurringNightmareAction.java
+++ b/src/main/java/theHexaghost/actions/RecurringNightmareAction.java
@@ -15,67 +15,70 @@ import static java.lang.Math.min;
 public class RecurringNightmareAction extends AbstractGameAction {
     private AbstractPlayer p;
     private ArrayList<AbstractCard> cannotExhume = new ArrayList<>();
+    private ArrayList<AbstractCard> canExhume = new ArrayList<>();
     public static final String[] EXTENDED_DESCRIPTIONS = CardCrawlGame.languagePack.getCardStrings(RecurringNightmare.ID).EXTENDED_DESCRIPTION;
 
     public RecurringNightmareAction(int amount) {
-        this.p = AbstractDungeon.player;// 27
-        this.setValues(this.p, AbstractDungeon.player, amount);// 28
-        this.actionType = ActionType.CARD_MANIPULATION;// 29
-        this.duration = Settings.ACTION_DUR_FAST;// 30
-    }// 31
+        this.p = AbstractDungeon.player;
+        this.setValues(this.p, AbstractDungeon.player, amount);
+        this.actionType = ActionType.CARD_MANIPULATION;
+        this.duration = Settings.ACTION_DUR_FAST;
+    }
 
     public void update() {
-        if (this.duration == Settings.ACTION_DUR_FAST) {// 35
-            if (AbstractDungeon.player.hand.size() == 10) {// 37
-                AbstractDungeon.player.createHandIsFullDialog();// 38
-                this.isDone = true;// 39
-            } else if (this.p.exhaustPile.isEmpty()) {// 44
-                this.isDone = true;// 45
+        if (this.duration == Settings.ACTION_DUR_FAST) {
+            if (AbstractDungeon.player.hand.size() == 10) {
+                AbstractDungeon.player.createHandIsFullDialog();
+                this.isDone = true;
+            } else if (this.p.exhaustPile.isEmpty()) {
+                this.isDone = true;
             } else {
                 for (AbstractCard c : AbstractDungeon.player.exhaustPile.group)
-                    if (!c.isEthereal) {// 47
-                        this.cannotExhume.add(c);// 48
+                    if (!c.isEthereal) {
+                        this.cannotExhume.add(c);
+                    } else {
+                        this.canExhume.add(c);
                     }
             }
 
-            if (p.exhaustPile.size() == cannotExhume.size()) {
+            if (canExhume.size() == 0) {
                 isDone = true;
                 return;
             }
 
-            if (this.p.exhaustPile.size() - cannotExhume.size() == amount) {// 48
-                for (AbstractCard c : p.exhaustPile.group) {
-                    if (c.isEthereal) {
-                        c.unfadeOut();// 57
-                        this.p.hand.addToHand(c);// 58
-                        this.p.exhaustPile.removeCard(c);// 63
-                        c.unhover();// 67
-                        c.fadingOut = false;// 68
-                        this.isDone = true;// 69
-                        break;
-                    }
+            // if the amount to exhume is greater than or equal to the amount of exhumable, exhume them all
+            if (canExhume.size() <= amount) {
+                for (AbstractCard c : canExhume) {
+                    c.unfadeOut();
+                    this.p.hand.addToHand(c);
+                    this.p.exhaustPile.removeCard(c);
+                    c.unhover();
+                    c.fadingOut = false;
+                    this.isDone = true;
+//                    break;
                 }
+                return;
             } else {
-
                 p.exhaustPile.group.removeAll(cannotExhume);
-                AbstractDungeon.gridSelectScreen.open(this.p.exhaustPile, min(amount, p.exhaustPile.size()), amount == 1 ? EXTENDED_DESCRIPTIONS[0] : (EXTENDED_DESCRIPTIONS[1] + amount + EXTENDED_DESCRIPTIONS[2]), false);// 96
-                this.tickDuration();// 97
+                AbstractDungeon.gridSelectScreen.open(this.p.exhaustPile, min(amount, p.exhaustPile.size()), amount == 1 ? EXTENDED_DESCRIPTIONS[0] : (EXTENDED_DESCRIPTIONS[1] + amount + EXTENDED_DESCRIPTIONS[2]), false);
+                this.tickDuration();
             }
         }
-        if (!AbstractDungeon.gridSelectScreen.selectedCards.isEmpty()) {// 102
-            for (AbstractCard c : AbstractDungeon.gridSelectScreen.selectedCards) {// 103 112
-                this.p.hand.addToHand(c);// 104
-                c.unfadeOut();// 57
-                this.p.exhaustPile.removeCard(c);// 63
-                c.unhover();// 67
-                c.fadingOut = false;// 68
+        if (!AbstractDungeon.gridSelectScreen.selectedCards.isEmpty()) {
+            for (AbstractCard c : AbstractDungeon.gridSelectScreen.selectedCards) {
+                c.unfadeOut();
+                this.p.hand.addToHand(c);
+                this.p.exhaustPile.removeCard(c);
+                c.unhover();
+                c.fadingOut = false;
             }
 
-            AbstractDungeon.gridSelectScreen.selectedCards.clear();// 114
-            this.p.hand.refreshHandLayout();// 115
-            this.p.exhaustPile.group.addAll(cannotExhume);// 118
+            AbstractDungeon.gridSelectScreen.selectedCards.clear();
+            this.p.hand.refreshHandLayout();
+            this.p.exhaustPile.group.addAll(cannotExhume);
+            isDone = true;
         }
 
-        this.tickDuration();// 128
+        this.tickDuration();
     }
-}// 40 46 53 70 93 98 129
+}

--- a/src/main/java/theHexaghost/cards/BurningQuestion.java
+++ b/src/main/java/theHexaghost/cards/BurningQuestion.java
@@ -36,9 +36,9 @@ public class BurningQuestion extends AbstractHexaCard {
     public void upgrade() {
         if (!upgraded) {
             upgradeName();
+            upgradeDamage(2);
+            upgradeBlock(2);
+            upgradeMagicNumber(2);
         }
-        upgradeDamage(2);
-        upgradeBlock(2);
-        upgradeMagicNumber(2);
     }
 }

--- a/src/main/java/theHexaghost/cards/StrikeFromBeyond.java
+++ b/src/main/java/theHexaghost/cards/StrikeFromBeyond.java
@@ -29,6 +29,7 @@ public class StrikeFromBeyond extends AbstractHexaCard {
         baseDamage = DAMAGE;
         baseMagicNumber = magicNumber = MAGIC;
         this.tags.add(SneckoMod.BANNEDFORSNECKO);
+        this.tags.add(CardTags.STRIKE);
     }
 
     public void use(AbstractPlayer p, AbstractMonster m) {

--- a/src/main/java/theHexaghost/ghostflames/AbstractGhostflame.java
+++ b/src/main/java/theHexaghost/ghostflames/AbstractGhostflame.java
@@ -104,6 +104,13 @@ public abstract class AbstractGhostflame {
         }
     }
 
+    public void forceCharge(){
+        if (charged){
+            extinguish();
+        }
+        charge();
+    }
+
     public abstract void onCharge();
 
     public void update() {

--- a/src/main/resources/downfallResources/localization/eng/EventStrings.json
+++ b/src/main/resources/downfallResources/localization/eng/EventStrings.json
@@ -123,9 +123,9 @@
     "NAME": "The Cursed Fountain",
     "DESCRIPTIONS": [
       "You come across a tinged #p~purple~ #p~liquid~ flowing endlessly from a fountain on a nearby wall. It is one you recognize as deadly to most creatures, but quite beneficial to those subjected to a curse.",
-      "As you drink the #p~liquid,~ you feel a #pdark #pgrasp reach into your mind. It feels luxurious and refreshing.",
-      "Sensing that this #p~liquid~ may be useful, you decide to capture some in a jar to use later. Creatures not attuned to the #pdark #pwater will surely suffer when doused in it.",
       "The fountain's #p~liquid~ is roiling in the souls of the lost. It seems a waste to not make use of them. You channel the souls into your form, ripping them from the #pcursed #pfountain's magic.",
+      "Sensing that this #p~liquid~ may be useful, you decide to capture some in a jar to use later. Creatures not attuned to the #pdark #pwater will surely suffer when doused in it.",
+      "As you drink the #p~liquid,~ you feel a #pdark #pgrasp reach into your mind. It feels luxurious and refreshing.",
       "Leaving the fountain behind, you continue on your way."
     ],
     "OPTIONS": [

--- a/src/main/resources/hexamodResources/localization/eng/CardStrings.json
+++ b/src/main/resources/hexamodResources/localization/eng/CardStrings.json
@@ -134,7 +134,7 @@
   "hexamod:RecurringNightmare": {
     "NAME": "Nightmare Vision",
     "DESCRIPTION": "expansioncontent:Exhume an Ethereal card. NL Exhaust.",
-    "UPGRADE_DESCRIPTION": "expansioncontent:Exhume 2 Ethereal cards. NL Exhaust.",
+    "UPGRADE_DESCRIPTION": "expansioncontent:Exhume !M! Ethereal cards. NL Exhaust.",
     "EXTENDED_DESCRIPTION": [
       "Choose an Ethereal card to return to your hand.",
       "Choose ",

--- a/src/main/resources/sneckomodResources/localization/eng/KeywordStrings.json
+++ b/src/main/resources/sneckomodResources/localization/eng/KeywordStrings.json
@@ -19,6 +19,6 @@
     "NAMES": [
       "offclass"
     ],
-    "DESCRIPTION": "An Offclass card is any obtainable card from a class other than your own (including Colorless cards)."
+    "DESCRIPTION": "An Offclass card is any obtainable card from a class other than your own (including Colorless cards, Curses, and Statuses)."
   }
 ]


### PR DESCRIPTION
Fixed Burning Question+ being upgradeable multiple times
Fixed Cursed Fountain event having mixed up strings (ENG localization only since I can't speak chinese)
Fixed Strike from Beyond not being a Strike card
Fixed Nightmare Vision+'s exhume action being weird
Slightly improved the Offclass keyword to clarify that statuses and curses are offclass.
Fixed Instant Inferno+ to force-ignite the active ghostflame correctly.