### PR TITLE
Fix Construction Form breaking Mode Shifter for the rest of the fight

### DIFF
--- a/src/main/java/guardian/powers/ModeShiftPower.java
+++ b/src/main/java/guardian/powers/ModeShiftPower.java
@@ -80,7 +80,7 @@ public class ModeShiftPower extends AbstractGuardianPower {
     @Override
     public int onLoseHp(int damageAmount) {
 
-        if (AbstractDungeon.getCurrRoom().phase == AbstractRoom.RoomPhase.COMBAT && this.active && !AbstractDungeon.player.hasPower(ConstructModePower.POWER_ID) && !AbstractDungeon.player.hasPower(BufferPower.POWER_ID)) {
+        if (AbstractDungeon.getCurrRoom().phase == AbstractRoom.RoomPhase.COMBAT && this.active && !AbstractDungeon.player.hasPower(BufferPower.POWER_ID)) {
             onSpecificTrigger(damageAmount);
         }
 


### PR DESCRIPTION
Remove an old check that was added back when C.Form prevented HP
instead of adding Strength.