### PR TITLE
Gremlin Rez/HP nerfs

### DIFF
--- a/src/main/java/gremlin/characters/GremlinCharacter.java
+++ b/src/main/java/gremlin/characters/GremlinCharacter.java
@@ -340,6 +340,10 @@ public class GremlinCharacter extends CustomPlayer {
         mobState.resurrect(this.maxHealth);
     }
 
+    public void resurrect(double multiplier) {
+        mobState.resurrect((int)(this.maxHealth*0.5));
+    }
+
     public boolean canRez() {
         return mobState.canRez();
     }

--- a/src/main/java/gremlin/patches/CampfireRestPatch.java
+++ b/src/main/java/gremlin/patches/CampfireRestPatch.java
@@ -24,7 +24,7 @@ public class CampfireRestPatch {
                 gremlinMob.mobState.campfireHeal(toHeal, gremlinMob.maxHealth);
             }
             if (gremlinMob.canRez()) {
-                gremlinMob.resurrect();
+                gremlinMob.resurrect(0.5);
             }
         }
     }

--- a/src/main/java/gremlin/patches/GremlinPostBossHealPatch.java
+++ b/src/main/java/gremlin/patches/GremlinPostBossHealPatch.java
@@ -20,7 +20,14 @@ public class GremlinPostBossHealPatch {
             if (AbstractDungeon.ascensionLevel >= 5) {
                 multiplier = .75f;
             }
-            ((GremlinCharacter)(AbstractDungeon.player)).mobState.postBossHeal(AbstractDungeon.player.maxHealth, multiplier);
+
+            // Only rez 1
+            if (((GremlinCharacter) AbstractDungeon.player).canRez()) {
+                ((GremlinCharacter) AbstractDungeon.player).resurrect(multiplier);
+            }
+
+            // Rez all
+            //((GremlinCharacter)(AbstractDungeon.player)).mobState.postBossHeal(AbstractDungeon.player.maxHealth, multiplier);
         }
         return SpireReturn.Continue();
     }

--- a/src/main/java/gremlin/patches/eventpatches/GhostsPatch.java
+++ b/src/main/java/gremlin/patches/eventpatches/GhostsPatch.java
@@ -1,0 +1,28 @@
+package gremlin.patches.eventpatches;
+
+import basemod.ReflectionHacks;
+import com.evacipated.cardcrawl.modthespire.lib.SpirePatch;
+import com.megacrit.cardcrawl.cards.colorless.Apparition;
+import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
+import com.megacrit.cardcrawl.events.city.Ghosts;
+import gremlin.characters.GremlinCharacter;
+
+public class GhostsPatch {
+    @SpirePatch(clz = Ghosts.class, method = SpirePatch.CONSTRUCTOR)
+    public static class GhostsConstructior
+    {
+        public static void Postfix(Ghosts __instance) {
+            if (AbstractDungeon.player instanceof GremlinCharacter) {
+                int dmg = (int) ReflectionHacks.getPrivate(__instance, Ghosts.class, "hpLoss");
+                dmg *= 5;
+                ReflectionHacks.setPrivate(__instance, Ghosts.class, "hpLoss", dmg);
+
+                if (AbstractDungeon.ascensionLevel >= 15) {
+                    __instance.imageEventText.updateDialogOption(0, Ghosts.OPTIONS[3] + dmg + Ghosts.OPTIONS[1], new Apparition());
+                } else {
+                    __instance.imageEventText.updateDialogOption(0, Ghosts.OPTIONS[0] + dmg + Ghosts.OPTIONS[1], new Apparition());
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/gremlin/patches/eventpatches/VampiresPatch.java
+++ b/src/main/java/gremlin/patches/eventpatches/VampiresPatch.java
@@ -1,0 +1,23 @@
+package gremlin.patches.eventpatches;
+
+import basemod.ReflectionHacks;
+import com.evacipated.cardcrawl.modthespire.lib.SpirePatch;
+import com.megacrit.cardcrawl.cards.colorless.Bite;
+import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
+import com.megacrit.cardcrawl.events.city.Vampires;
+import gremlin.characters.GremlinCharacter;
+
+public class VampiresPatch {
+    @SpirePatch(clz = Vampires.class, method = SpirePatch.CONSTRUCTOR)
+    public static class VampiresConstructor
+    {
+        public static void Postfix(Vampires __instance) {
+            if (AbstractDungeon.player instanceof GremlinCharacter) {
+                int dmg = (int) ReflectionHacks.getPrivate(__instance, Vampires.class, "maxHpLoss");
+                dmg *= 5;
+                ReflectionHacks.setPrivate(__instance, Vampires.class, "maxHpLoss", dmg);
+                __instance.imageEventText.updateDialogOption(0, Vampires.OPTIONS[0] + dmg + Vampires.OPTIONS[1], new Bite());
+            }
+        }
+    }
+}


### PR DESCRIPTION
Nerfing post boss and campfire resurrections.

Fixing the percentage max hp loss events (vampires/ghosts)