### PR TITLE
Snecko's Identify is now seeded and can be canceled

### DIFF
--- a/src/main/java/saveData/SaveData.java
+++ b/src/main/java/saveData/SaveData.java
@@ -6,6 +6,7 @@ import com.google.gson.GsonBuilder;
 import com.megacrit.cardcrawl.cards.AbstractCard;
 import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
 import com.megacrit.cardcrawl.map.MapRoomNode;
+import com.megacrit.cardcrawl.random.Random;
 import com.megacrit.cardcrawl.rooms.MonsterRoomBoss;
 import com.megacrit.cardcrawl.saveAndContinue.SaveAndContinue;
 import com.megacrit.cardcrawl.saveAndContinue.SaveFile;
@@ -43,6 +44,7 @@ public class SaveData {
     public static final String ACT_3_BOSS_SLAIN = "ACT_3_BOSS_SLAIN";
     public static final String VALID_COLORS = "VALID_COLORS";
     public static final String PURE_SNECKO_MODE = "PURE_SNECKO_MODE";
+    public static final String IDENTIFY_RNG_COUNT = "IDENTIFY_RNG_COUNT";
 
     private static Logger saveLogger = LogManager.getLogger("downfallSaveData");
     //data is stored here in addition to the actual location
@@ -74,6 +76,8 @@ public class SaveData {
     private static ArrayList<AbstractCard.CardColor> saveCacheColors;
     private static boolean pureSneckoMode;
 
+    private static int identifyRngCount;
+
     //Save data whenever SaveFile is constructed
     @SpirePatch(
             clz = SaveFile.class,
@@ -81,6 +85,7 @@ public class SaveData {
             paramtypez = {SaveFile.SaveType.class}
     )
     public static class SaveTheSaveData {
+
         @SpirePostfixPatch
         public static void saveAllTheSaveData(SaveFile __instance, SaveFile.SaveType type) {
             evilMode = EvilModeCharacterSelect.evilMode;
@@ -112,6 +117,8 @@ public class SaveData {
 
             saveCacheColors = SneckoMod.validColors;
             pureSneckoMode = SneckoMod.pureSneckoMode;
+
+            identifyRngCount = SneckoMod.identifyRng.counter;
 
             saveLogger.info("Saved Evil Mode: " + evilMode);
         }
@@ -146,6 +153,7 @@ public class SaveData {
             params.put(ACT_3_BOSS_SLAIN, act3BossSlain);
             params.put(VALID_COLORS, saveCacheColors);
             params.put(PURE_SNECKO_MODE, pureSneckoMode);
+            params.put(IDENTIFY_RNG_COUNT, identifyRngCount);
         }
 
         private static class Locator extends SpireInsertLocator {
@@ -197,6 +205,8 @@ public class SaveData {
 
                 saveCacheColors = data.VALID_COLORS;
                 pureSneckoMode = data.PURE_SNECKO_MODE;
+
+                identifyRngCount = data.IDENTIFY_RNG_COUNT;
 
                 saveLogger.info("Loaded downfall save data successfully.");
             } catch (Exception e) {
@@ -260,6 +270,8 @@ public class SaveData {
 
             SneckoMod.validColors = saveCacheColors;
             SneckoMod.pureSneckoMode = pureSneckoMode;
+
+            SneckoMod.identifyRng = new Random(file.seed, identifyRngCount);
 
             SneckoMod.updateAllUnknownReplacements();
 

--- a/src/main/java/saveData/downfallSaveData.java
+++ b/src/main/java/saveData/downfallSaveData.java
@@ -32,4 +32,6 @@ public class downfallSaveData {
 
     public ArrayList<AbstractCard.CardColor> VALID_COLORS = new ArrayList<>();
     public boolean PURE_SNECKO_MODE;
+
+    public int IDENTIFY_RNG_COUNT;
 }

--- a/src/main/java/sneckomod/SneckoMod.java
+++ b/src/main/java/sneckomod/SneckoMod.java
@@ -24,6 +24,7 @@ import com.megacrit.cardcrawl.dungeons.TheCity;
 import com.megacrit.cardcrawl.events.city.BackToBasics;
 import com.megacrit.cardcrawl.events.exordium.Sssserpent;
 import com.megacrit.cardcrawl.helpers.CardLibrary;
+import com.megacrit.cardcrawl.random.Random;
 import downfall.cards.OctoChoiceCard;
 import downfall.downfallMod;
 import downfall.events.Serpent_Evil;
@@ -96,6 +97,8 @@ public class SneckoMod implements
     public static com.megacrit.cardcrawl.cards.AbstractCard.CardTags RNG;
     @SpireEnum
     public static com.megacrit.cardcrawl.cards.AbstractCard.CardTags BANNEDFORSNECKO;
+
+    public static Random identifyRng;
 
     public static ArrayList<AbstractCard.CardColor> validColors = new ArrayList<>();
     public static ArrayList<UnknownClass> unknownClasses = new ArrayList<>();

--- a/src/main/java/sneckomod/patches/GenerateSeedsPatch.java
+++ b/src/main/java/sneckomod/patches/GenerateSeedsPatch.java
@@ -1,0 +1,19 @@
+package sneckomod.patches;
+
+import com.evacipated.cardcrawl.modthespire.lib.SpirePatch;
+import com.evacipated.cardcrawl.modthespire.lib.SpirePostfixPatch;
+import com.megacrit.cardcrawl.core.Settings;
+import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
+import com.megacrit.cardcrawl.random.Random;
+import sneckomod.SneckoMod;
+
+@SpirePatch(
+        clz = AbstractDungeon.class,
+        method = "generateSeeds"
+)
+public class GenerateSeedsPatch {
+    @SpirePostfixPatch
+    public static void Postfix() {
+        SneckoMod.identifyRng = new Random(Settings.seed);
+    }
+}

--- a/src/main/java/sneckomod/relics/SuperSneckoEye.java
+++ b/src/main/java/sneckomod/relics/SuperSneckoEye.java
@@ -29,16 +29,18 @@ public class SuperSneckoEye extends CustomRelic {
     }
 
     @Override
-    public void obtain() {
+    public void instantObtain() {
+        // instantObtain() is called for chest loot and shop purchases
         if (AbstractDungeon.player.hasRelic(SneckoEye.ID)) {
             for (int i = 0; i < AbstractDungeon.player.relics.size(); ++i) {
                 if (AbstractDungeon.player.relics.get(i).relicId.equals(SneckoEye.ID)) {
+                    AbstractDungeon.player.relics.get(i).onUnequip();
                     instantObtain(AbstractDungeon.player, i, true);
                     break;
                 }
             }
         } else {
-            super.obtain();
+            super.instantObtain();
         }
     }
 
@@ -50,6 +52,7 @@ public class SuperSneckoEye extends CustomRelic {
                 public void update() {
                     isDone = true;
                     if (card.cost == 3 && !activated) {
+                        stopPulse();
                         flash();
                         activated = true;
                         card.cost = 0;// 35

--- a/src/main/java/sneckomod/ui/LockInCampfireEffect.java
+++ b/src/main/java/sneckomod/ui/LockInCampfireEffect.java
@@ -1,36 +1,27 @@
 package sneckomod.ui;
 
 import com.badlogic.gdx.Gdx;
-/*     */ import com.badlogic.gdx.Graphics;
-/*     */ import com.badlogic.gdx.graphics.Color;
-/*     */ import com.badlogic.gdx.graphics.g2d.SpriteBatch;
-/*     */ import com.badlogic.gdx.math.Interpolation;
-/*     */ import com.megacrit.cardcrawl.cards.AbstractCard;
-/*     */ import com.megacrit.cardcrawl.cards.CardGroup;
+import com.badlogic.gdx.graphics.Color;
+import com.badlogic.gdx.graphics.g2d.SpriteBatch;
+import com.badlogic.gdx.math.Interpolation;
+import com.megacrit.cardcrawl.cards.AbstractCard;
+import com.megacrit.cardcrawl.cards.CardGroup;
 import com.megacrit.cardcrawl.cards.colorless.Madness;
-import com.megacrit.cardcrawl.characters.AbstractPlayer;
-/*     */ import com.megacrit.cardcrawl.core.CardCrawlGame;
-/*     */ import com.megacrit.cardcrawl.core.Settings;
-/*     */ import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
-/*     */ import com.megacrit.cardcrawl.dungeons.AbstractDungeon.CurrentScreen;
-/*     */ import com.megacrit.cardcrawl.helpers.CardLibrary;
+import com.megacrit.cardcrawl.core.CardCrawlGame;
+import com.megacrit.cardcrawl.core.Settings;
+import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
+import com.megacrit.cardcrawl.helpers.CardLibrary;
 import com.megacrit.cardcrawl.helpers.ImageMaster;
-/*     */ import com.megacrit.cardcrawl.localization.UIStrings;
-/*     */ import com.megacrit.cardcrawl.metrics.MetricData;
-/*     */ import com.megacrit.cardcrawl.relics.AbstractRelic;
-/*     */ import com.megacrit.cardcrawl.rooms.AbstractRoom;
-import com.megacrit.cardcrawl.rooms.AbstractRoom.RoomPhase;
-/*     */ import com.megacrit.cardcrawl.rooms.CampfireUI;
+import com.megacrit.cardcrawl.localization.UIStrings;
+import com.megacrit.cardcrawl.random.Random;
+import com.megacrit.cardcrawl.rooms.AbstractRoom;
 import com.megacrit.cardcrawl.rooms.RestRoom;
-/*     */ import com.megacrit.cardcrawl.screens.select.GridCardSelectScreen;
-/*     */ import com.megacrit.cardcrawl.ui.buttons.ProceedButton;
-/*     */ import com.megacrit.cardcrawl.vfx.cardManip.ShowCardAndObtainEffect;
-import com.megacrit.cardcrawl.vfx.cardManip.ShowCardBrieflyEffect;
-import guardian.GuardianMod;
+import com.megacrit.cardcrawl.screens.select.GridCardSelectScreen;
+import com.megacrit.cardcrawl.vfx.cardManip.ShowCardAndObtainEffect;
+import sneckomod.SneckoMod;
 import sneckomod.cards.unknowns.AbstractUnknownCard;
 import sneckomod.patches.UnknownExtraUiPatch;
 import sneckomod.relics.SuperSneckoSoul;
-/*     */ import java.util.ArrayList;
 
 public class LockInCampfireEffect extends com.megacrit.cardcrawl.vfx.AbstractGameEffect {
     private static final UIStrings uiStrings = CardCrawlGame.languagePack.getUIString("sneckomod:LockInBonfireOptions");
@@ -40,11 +31,14 @@ public class LockInCampfireEffect extends com.megacrit.cardcrawl.vfx.AbstractGam
     private boolean openedScreen = false;
     private Color screenColor = AbstractDungeon.fadeColor.cpy();
 
+    public static int identifyRngCount;
 
     public LockInCampfireEffect() {
         this.duration = 1.5F;
         this.screenColor.a = 0.0F;
         AbstractDungeon.overlayMenu.proceedButton.hide();
+
+        identifyRngCount = SneckoMod.identifyRng.counter;
     }
 
     public void update() {
@@ -53,35 +47,42 @@ public class LockInCampfireEffect extends com.megacrit.cardcrawl.vfx.AbstractGam
             updateBlackScreenColor();
         }
 
+        if (!AbstractDungeon.isScreenUp) {
+            if (!AbstractDungeon.gridSelectScreen.selectedCards.isEmpty()) {
+                for (AbstractCard c : AbstractDungeon.gridSelectScreen.selectedCards) {
 
-        if ((!AbstractDungeon.isScreenUp) && (!AbstractDungeon.gridSelectScreen.selectedCards.isEmpty())) {
-            for (AbstractCard c : AbstractDungeon.gridSelectScreen.selectedCards) {
+                    AbstractDungeon.effectsQueue.add(new ShowCardAndObtainEffect(c, (float) Settings.WIDTH * .75F, (float) Settings.HEIGHT / 2.0F));
 
-                AbstractDungeon.effectsQueue.add(new ShowCardAndObtainEffect(c, (float) Settings.WIDTH * .75F, (float) Settings.HEIGHT / 2.0F));
+                    AbstractDungeon.topLevelEffects.add(new com.megacrit.cardcrawl.vfx.cardManip.PurgeCardEffect(
 
-                AbstractDungeon.topLevelEffects.add(new com.megacrit.cardcrawl.vfx.cardManip.PurgeCardEffect(
-
-                        (AbstractCard) UnknownExtraUiPatch.parentCard.get(c), com.megacrit.cardcrawl.core.Settings.WIDTH * 0.35F, com.megacrit.cardcrawl.core.Settings.HEIGHT / 2));
+                            (AbstractCard) UnknownExtraUiPatch.parentCard.get(c), Settings.WIDTH * 0.35F, Settings.HEIGHT / 2));
 
 
-                AbstractDungeon.player.masterDeck.removeCard(UnknownExtraUiPatch.parentCard.get(c));
+                    AbstractDungeon.player.masterDeck.removeCard(UnknownExtraUiPatch.parentCard.get(c));
 
+                }
+                AbstractDungeon.gridSelectScreen.selectedCards.clear();
+                ((RestRoom) AbstractDungeon.getCurrRoom()).fadeIn();
+                LockInCampfireOption.usedIdentify = true;
+            } else if (this.openedScreen && !LockInCampfireOption.usedIdentify) {
+                // Cancelled
+                isDone = true;
+                ((RestRoom) AbstractDungeon.getCurrRoom()).campfireUI.reopen();
+                SneckoMod.identifyRng = new Random(Settings.seed, identifyRngCount);
             }
-            AbstractDungeon.gridSelectScreen.selectedCards.clear();
-            ((RestRoom) AbstractDungeon.getCurrRoom()).fadeIn();
         }
-
 
         if ((this.duration < 1.0F) && (!this.openedScreen)) {
             this.openedScreen = true;
 
             CardGroup cg = new CardGroup(CardGroup.CardGroupType.UNSPECIFIED);
+
             for (AbstractCard c : AbstractDungeon.player.masterDeck.group) {
                 c.update();
                 AbstractCard c2;
                 if (c instanceof AbstractUnknownCard){
                     if (((AbstractUnknownCard) c).myList().size() > 0) {
-                        c2 = CardLibrary.getCard(((AbstractUnknownCard) c).myList().get(AbstractDungeon.cardRng.random(0, ((AbstractUnknownCard) c).myList().size() - 1))).makeCopy();
+                        c2 = CardLibrary.getCard(((AbstractUnknownCard) c).myList().get(SneckoMod.identifyRng.random(0, ((AbstractUnknownCard) c).myList().size() - 1))).makeCopy();
                     } else {
                         c2 = CardLibrary.getCard(Madness.ID).makeCopy();
                     }
@@ -92,9 +93,8 @@ public class LockInCampfireEffect extends com.megacrit.cardcrawl.vfx.AbstractGam
 
                 }
             }
-
-
-            AbstractDungeon.gridSelectScreen.open(cg, 1, TEXT[3], false, false, false, false);
+            AbstractDungeon.overlayMenu.cancelButton.show(GridCardSelectScreen.TEXT[1]);
+            AbstractDungeon.gridSelectScreen.open(cg, 1, TEXT[3], false, false, true, false);
 
         }
 

--- a/src/main/java/sneckomod/ui/LockInCampfireOption.java
+++ b/src/main/java/sneckomod/ui/LockInCampfireOption.java
@@ -5,27 +5,23 @@ import com.megacrit.cardcrawl.cards.AbstractCard;
 import com.megacrit.cardcrawl.core.CardCrawlGame;
 import com.megacrit.cardcrawl.core.Settings;
 import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
-import com.megacrit.cardcrawl.helpers.CardLibrary;
-import com.megacrit.cardcrawl.helpers.ImageMaster;
 import com.megacrit.cardcrawl.helpers.MathHelper;
 import com.megacrit.cardcrawl.localization.UIStrings;
 import com.megacrit.cardcrawl.ui.campfire.AbstractCampfireOption;
-import guardian.GuardianMod;
-import guardian.vfx.SocketGemEffect;
-import sneckomod.SneckoMod;
+import downfall.util.TextureLoader;
 import sneckomod.cards.unknowns.AbstractUnknownCard;
-import sneckomod.patches.UnknownExtraUiPatch;
 import sneckomod.relics.SuperSneckoSoul;
 
-import java.lang.reflect.Array;
 import java.util.ArrayList;
 
 
 public class LockInCampfireOption extends AbstractCampfireOption {
     public static final String[] DESCRIPTIONS;
     private static final UIStrings UI_STRINGS;
+    public static boolean usedIdentify = false;
 
     private ArrayList<AbstractCard> validCards = new ArrayList<>();
+
 
     static {
         UI_STRINGS = CardCrawlGame.languagePack.getUIString("sneckomod:LockInBonfireOptions");
@@ -44,7 +40,6 @@ public class LockInCampfireOption extends AbstractCampfireOption {
             }
         }
 
-
         this.usable = active;
         if (active) {
             if (AbstractDungeon.player.hasRelic(SuperSneckoSoul.ID)) {
@@ -52,25 +47,37 @@ public class LockInCampfireOption extends AbstractCampfireOption {
             } else {
                 this.description = DESCRIPTIONS[1];
             }
-            this.img = ImageMaster.loadImage("sneckomodResources/images/ui/lockincampfire.png");
         } else {
             this.description = DESCRIPTIONS[2];
-            this.img = ImageMaster.loadImage("sneckomodResources/images/ui/lockincampfiredisabled.png");
+        }
+        usedIdentify = false;
+        updateImage(active);
+
+    }
+
+    public void updateImage(boolean active) {
+        if (active) {
+            this.img = TextureLoader.getTexture("sneckomodResources/images/ui/lockincampfire.png");
+        } else {
+            this.img = TextureLoader.getTexture("sneckomodResources/images/ui/lockincampfiredisabled.png");
         }
     }
 
     @Override
     public void useOption() {
         if (this.usable) {
-            AbstractDungeon.effectList.add(new LockInCampfireEffect());
-            this.usable = false;
-            this.img = ImageMaster.loadImage("sneckomodResources/images/ui/lockincampfiredisabled.png");
+            LockInCampfireEffect e = new LockInCampfireEffect();
+            AbstractDungeon.effectList.add(e);
         }
     }
 
     @Override
     public void update() {
         float hackScale = (float) ReflectionHacks.getPrivate(this, AbstractCampfireOption.class, "scale");
+        if (usable && usedIdentify) {
+            usable = false;
+            updateImage(false);
+        }
 
         if (this.hb.hovered) {
 


### PR DESCRIPTION
Cards shown by Identify will be the same at subsequent campfires until
a card is identified. Identify uses a new, distinct RNG to ensure no
other actions will affect the cards shown, with the exception that
removing an unknown might reroll any that were acquired more recently.

Memorize will not affect the Identify RNG.