### PR TITLE
[WIP] Event metrics logging audit

### DIFF
--- a/src/main/java/downfall/events/Augmenter_Evil.java
+++ b/src/main/java/downfall/events/Augmenter_Evil.java
@@ -65,7 +65,7 @@ public class Augmenter_Evil extends AbstractImageEvent {
                 switch (buttonPressed) {
                     case 0:
                         AbstractCard jax = new JAX();
-                        logMetricObtainCard("Drug Dealer", "Obtain J.A.X.", jax);
+                        logMetricObtainCard(ID, "Obtain J.A.X.", jax);
                         this.imageEventText.updateBodyText(DESCRIPTIONS[1]);
                         AbstractDungeon.effectList.add(new ShowCardAndObtainEffect(jax, (float) (Settings.WIDTH / 2), (float) (Settings.HEIGHT / 2)));
                         this.imageEventText.updateDialogOption(0, OPTIONS[3]);
@@ -88,12 +88,13 @@ public class Augmenter_Evil extends AbstractImageEvent {
                             AbstractDungeon.getCurrRoom().spawnRelicAndObtain(this.drawX, this.drawY, (AbstractRelic) r);
                         }
 
-                        logMetricObtainRelic("Drug Dealer", "Inject Mutagens", (AbstractRelic) r);
+                        logMetricObtainRelic(ID, "Inject Mutagens", (AbstractRelic) r);
                         this.imageEventText.updateDialogOption(0, OPTIONS[3]);
                         this.imageEventText.clearRemainingOptions();
                         break;
                     case 3:
                         //SlimeboundMod.logger.info("fight");
+                        logMetric(ID, "Fight");
 
                         AbstractDungeon.getCurrRoom().monsters = MonsterHelper.getEncounter("downfall:Augmenter");
                         AbstractDungeon.getCurrRoom().rewards.clear();
@@ -145,7 +146,7 @@ public class Augmenter_Evil extends AbstractImageEvent {
                 }
 
                 AbstractDungeon.gridSelectScreen.selectedCards.clear();
-                logMetricTransformCards("Drug Dealer", "Became Test Subject", transformedCards, obtainedCards);
+                logMetricTransformCards(ID, "Became Test Subject", transformedCards, obtainedCards);
                 AbstractDungeon.getCurrRoom().rewardPopOutTimer = 0.25F;
             }
         }

--- a/src/main/java/downfall/events/Bandits_Evil.java
+++ b/src/main/java/downfall/events/Bandits_Evil.java
@@ -16,6 +16,7 @@ import downfall.relics.RedIOU;
 import downfall.vfx.StealRelicEffect;
 
 import java.util.ArrayList;
+import java.util.Collections;
 
 public class Bandits_Evil extends AbstractEvent {
     public static final String ID = downfallMod.makeID("Bandits");
@@ -100,9 +101,12 @@ public class Bandits_Evil extends AbstractEvent {
                         this.roomEventText.updateDialogOption(0, OPTIONS[3]);// 62
                         this.roomEventText.clearRemainingOptions();// 63
                         this.screen = CUR_SCREEN.COMPLETE;
+                        logMetric(ID, "Hired Bandits",
+                                null, null, null, null,
+                                Collections.singletonList(RedIOU.ID), null, Collections.singletonList(wantThisOne.relicId), 0, 0, 0, 0, 0, 0);// 68
                         return;// 65
                     case 1:
-                        logMetric("Masked Bandits", "Fought Bandits");// 68
+                        logMetric(ID, "Fought Bandits");// 68
                         if (Settings.isDailyRun) {// 70
                             AbstractDungeon.getCurrRoom().addGoldToRewards(AbstractDungeon.miscRng.random(30));// 71
                         } else {

--- a/src/main/java/downfall/events/Beggar_Evil.java
+++ b/src/main/java/downfall/events/Beggar_Evil.java
@@ -170,6 +170,7 @@ public class Beggar_Evil extends AbstractImageEvent {
                         AbstractDungeon.getCurrRoom().monsters = monsters;
                         AbstractDungeon.getCurrRoom().rewards.clear();
                         AbstractDungeon.getCurrRoom().rewardAllowed = false;
+                        AbstractDungeon.lastCombatMetricKey = "Hired Bodyguards";
                         this.enterCombatFromImage();
                         break;
                 }

--- a/src/main/java/downfall/events/Beggar_Evil.java
+++ b/src/main/java/downfall/events/Beggar_Evil.java
@@ -17,6 +17,9 @@ import com.megacrit.cardcrawl.vfx.cardManip.ShowCardAndObtainEffect;
 import downfall.downfallMod;
 import slimebound.SlimeboundMod;
 
+import java.util.ArrayList;
+import java.util.Collections;
+
 public class Beggar_Evil extends AbstractImageEvent {
     public static final String ID = downfallMod.makeID("Beggar");
     public static final String NAME;
@@ -67,15 +70,20 @@ public class Beggar_Evil extends AbstractImageEvent {
                 AbstractDungeon.topLevelEffects.add(new PurgeCardEffect(c, (float) (Settings.WIDTH / 2), (float) (Settings.HEIGHT / 2)));
                 AbstractDungeon.player.masterDeck.removeCard(c);
                 AbstractDungeon.gridSelectScreen.selectedCards.remove(c);
+                logMetricRemoveCards(ID, "Intimidate", Collections.singletonList(c.cardID));
             } else {
+                ArrayList<String> cards = new ArrayList<>();
                 AbstractCard c = AbstractDungeon.gridSelectScreen.selectedCards.get(0);
                 AbstractDungeon.topLevelEffects.add(new PurgeCardEffect(c, (Settings.WIDTH * 0.3F), (float) (Settings.HEIGHT / 2)));
                 AbstractDungeon.player.masterDeck.removeCard(c);
                 AbstractDungeon.gridSelectScreen.selectedCards.remove(c);
+                cards.add(c.cardID);
                 c = AbstractDungeon.gridSelectScreen.selectedCards.get(1);
                 AbstractDungeon.topLevelEffects.add(new PurgeCardEffect(c, (Settings.WIDTH * 0.7F), (float) (Settings.HEIGHT / 2)));
                 AbstractDungeon.player.masterDeck.removeCard(c);
                 AbstractDungeon.gridSelectScreen.selectedCards.remove(c);
+                cards.add(c.cardID);
+                logMetricRemoveCards(ID, "Threaten", cards);
             }
         }
     }
@@ -90,20 +98,20 @@ public class Beggar_Evil extends AbstractImageEvent {
                     this.screen = CurScreen.CLERICFRESHINTRO;
                     this.imageEventText.updateBodyText(DESCRIPTIONSALT[0]);
 
-                    this.imageEventText.setDialogOption(OPTIONSOG[0] + this.gold + OPTIONSOG[4]);
-                    this.imageEventText.setDialogOption(OPTIONSOG[1]);
+                    this.imageEventText.setDialogOption(OPTIONSOG[0] + this.gold + OPTIONSOG[4]); // Punch: gain souls
+                    this.imageEventText.setDialogOption(OPTIONSOG[1]); // Intimidate: remove 1 card
 
                 } else if (Cleric_Evil.heDead) {
                     this.screen = CurScreen.CLERICDEADINTRO;
                     this.imageEventText.updateBodyText(DESCRIPTIONSALT[1]);
 
-                    this.imageEventText.setDialogOption(OPTIONSOG[0] + this.gold + OPTIONSOG[4] + OPTIONSALT[0], new Pride());
-                    this.imageEventText.setDialogOption(OPTIONS[5]);
+                    this.imageEventText.setDialogOption(OPTIONSOG[0] + this.gold + OPTIONSOG[4] + OPTIONSALT[0], new Pride()); // Punch: gain souls, curse
+                    this.imageEventText.setDialogOption(OPTIONS[5]); // Leave
                 } else {
                     this.imageEventText.loadImage("images/events/cleric.jpg");
                     this.screen = CurScreen.CLERICALIVEINTRO;
-                    this.imageEventText.updateBodyText(DESCRIPTIONSALT[4]);
-                    this.imageEventText.setDialogOption(OPTIONSALT[1]);
+                    this.imageEventText.updateBodyText(DESCRIPTIONSALT[4]); // CLERIC BOUGHT PROTECTION!
+                    this.imageEventText.setDialogOption(OPTIONSALT[1]); // Fight
 
                 }
                 return;
@@ -117,6 +125,7 @@ public class Beggar_Evil extends AbstractImageEvent {
                         CardCrawlGame.sound.play("BLUNT_HEAVY");
                         this.screen = CurScreen.END;
                         this.imageEventText.setDialogOption(OPTIONS[5]);
+                        logMetricGainGold(ID, "Punch", this.gold);
                         break;
                     case 1:
                         this.imageEventText.clearAllDialogs();
@@ -135,16 +144,19 @@ public class Beggar_Evil extends AbstractImageEvent {
                         AbstractDungeon.effectList.add(new RainingGoldEffect(this.gold));
                         AbstractDungeon.player.gainGold(this.gold);
                         CardCrawlGame.sound.play("BLUNT_HEAVY");
-                        AbstractDungeon.effectList.add(new ShowCardAndObtainEffect(new Pride(), (float) Settings.WIDTH / 2.0F, (float) Settings.HEIGHT / 2.0F));
+                        Pride curse = new Pride();
+                        AbstractDungeon.effectList.add(new ShowCardAndObtainEffect(curse, (float) Settings.WIDTH / 2.0F, (float) Settings.HEIGHT / 2.0F));
 
                         this.screen = CurScreen.END;
                         this.imageEventText.setDialogOption(OPTIONS[5]);
+                        logMetricGainGoldAndCard(ID, "Punch", curse, this.gold);
                         break;
                     case 1:
                         this.imageEventText.clearAllDialogs();
                         this.imageEventText.updateBodyText(DESCRIPTIONSALT[3]);
                         this.screen = CurScreen.END;
                         this.imageEventText.setDialogOption(OPTIONS[5]);
+                        logMetricIgnored(ID);
                         break;
                 }
                 return;
@@ -167,11 +179,12 @@ public class Beggar_Evil extends AbstractImageEvent {
                     case 0:
                         this.imageEventText.clearAllDialogs();
                         this.imageEventText.updateBodyText(DESCRIPTIONSALT[6]);
-                        AbstractDungeon.effectList.add(new RainingGoldEffect(this.gold * 3));
+                        AbstractDungeon.effectList.add(new RainingGoldEffect(this.gold * 2));
                         AbstractDungeon.player.gainGold(this.gold * 2);
                         CardCrawlGame.sound.play("BLUNT_HEAVY");
                         this.screen = CurScreen.END;
                         this.imageEventText.setDialogOption(OPTIONS[5]);
+                        logMetricGainGold(ID, "Punch", this.gold * 2);
                         break;
                     case 1:
                         AbstractDungeon.getCurrRoom().rewards.clear();
@@ -199,8 +212,8 @@ public class Beggar_Evil extends AbstractImageEvent {
             AbstractDungeon.player.preBattlePrep();
             this.imageEventText.clearAllDialogs();
             this.imageEventText.updateBodyText(DESCRIPTIONSALT[5]);
-            this.imageEventText.setDialogOption(OPTIONSOG[0] + (this.gold * 3) + OPTIONSOG[4]);
-            this.imageEventText.setDialogOption(OPTIONSALT[2]);
+            this.imageEventText.setDialogOption(OPTIONSOG[0] + (this.gold * 2) + OPTIONSOG[4]); // Punch: gain many souls
+            this.imageEventText.setDialogOption(OPTIONSALT[2]); // Threaten: remove 2 cards
             this.enterImageFromCombat();
         }
 

--- a/src/main/java/downfall/events/BonfireSpirits_Evil.java
+++ b/src/main/java/downfall/events/BonfireSpirits_Evil.java
@@ -64,23 +64,23 @@ public class BonfireSpirits_Evil extends AbstractImageEvent {
             this.offeredCard = AbstractDungeon.gridSelectScreen.selectedCards.remove(0);
             switch (this.offeredCard.rarity) {
                 case CURSE:
-                    logMetricRemoveCardAndObtainRelic("Bonfire Elementals", "Offered Curse", this.offeredCard, new SpiritPoop());
+                    logMetricRemoveCardAndObtainRelic(ID, "Offered Curse", this.offeredCard, new SpiritPoop());
                     break;
                 case BASIC:
-                    logMetricCardRemoval("Bonfire Elementals", "Offered Basic", this.offeredCard);
+                    logMetricCardRemoval(ID, "Offered Basic", this.offeredCard);
                     break;
                 case COMMON:
-                    logMetricCardRemovalAndHeal("Bonfire Elementals", "Offered Common", this.offeredCard, 5);
+                    logMetricCardRemovalAndHeal(ID, "Offered Common", this.offeredCard, 5);
                 case SPECIAL:
-                    logMetricCardRemovalAndHeal("Bonfire Elementals", "Offered Special", this.offeredCard, 5);
+                    logMetricCardRemovalAndHeal(ID, "Offered Special", this.offeredCard, 5);
                     break;
                 case UNCOMMON:
                     int heal = AbstractDungeon.player.maxHealth - AbstractDungeon.player.currentHealth;
-                    logMetricCardRemovalAndHeal("Bonfire Elementals", "Offered Uncommon", this.offeredCard, heal);
+                    logMetricCardRemovalAndHeal(ID, "Offered Uncommon", this.offeredCard, heal);
                     break;
                 case RARE:
                     int heal2 = AbstractDungeon.player.maxHealth - AbstractDungeon.player.currentHealth;
-                    logMetricCardRemovalHealMaxHPUp("Bonfire Elementals", "Offered Rare", this.offeredCard, heal2, 10);
+                    logMetricCardRemovalHealMaxHPUp(ID, "Offered Rare", this.offeredCard, heal2, 10);
             }
 
             this.setReward(this.offeredCard.rarity);
@@ -135,6 +135,8 @@ public class BonfireSpirits_Evil extends AbstractImageEvent {
                         AbstractDungeon.player.loseGold(150);
                         AbstractDungeon.player.increaseMaxHp(10, false);
                         AbstractDungeon.player.heal(AbstractDungeon.player.maxHealth);
+                        logMetric(ID, "Donate", null, null, null, null, null, null, null,
+                                0, 10, 0, 10, 0, 150);
                         this.screen = CUR_SCREEN.COMPLETE;
                         break;
                     }

--- a/src/main/java/downfall/events/Cleric_Evil.java
+++ b/src/main/java/downfall/events/Cleric_Evil.java
@@ -52,7 +52,7 @@ public class Cleric_Evil extends AbstractImageEvent {
         if (!AbstractDungeon.gridSelectScreen.selectedCards.isEmpty()) {
             AbstractCard c = AbstractDungeon.gridSelectScreen.selectedCards.get(0);
             AbstractDungeon.topLevelEffects.add(new PurgeCardEffect(c, (float) (Settings.WIDTH / 2), (float) (Settings.HEIGHT / 2)));
-            AbstractEvent.logMetricCardRemovalAtCost("The Cleric", "Card Removal", c, 0);
+            AbstractEvent.logMetricCardRemovalAtCost(ID, "Card Removal", c, 0);
             AbstractDungeon.player.masterDeck.removeCard(c);
             AbstractDungeon.gridSelectScreen.selectedCards.remove(c);
         }
@@ -68,6 +68,7 @@ public class Cleric_Evil extends AbstractImageEvent {
                         AbstractDungeon.player.gainGold(this.gold);
                         CardCrawlGame.sound.play("BLUNT_HEAVY");
                         heDead = true;
+                        logMetricGainGold(ID, "Punch", this.gold);
                         break;
                     case 1:
                         this.imageEventText.updateBodyText(DESC[2]);

--- a/src/main/java/downfall/events/Colosseum_Evil.java
+++ b/src/main/java/downfall/events/Colosseum_Evil.java
@@ -57,6 +57,7 @@ public class Colosseum_Evil extends AbstractImageEvent {
                         this.screen = CurScreen.FIGHT;
                         this.imageEventText.updateBodyText(DESCRIPTIONS[2] + DESCRIPTIONS[3]);
                         //SlimeboundMod.logger.info("fight");
+                        logMetric(ID, "Fought Nobs");
                         AbstractDungeon.getCurrRoom().monsters = MonsterHelper.getEncounter("Colosseum Nobs");
                         AbstractDungeon.getCurrRoom().rewards.clear();
                         AbstractDungeon.getCurrRoom().addRelicToRewards(AbstractRelic.RelicTier.RARE);
@@ -72,6 +73,7 @@ public class Colosseum_Evil extends AbstractImageEvent {
                         this.screen = CurScreen.FIGHT;
                         this.imageEventText.updateBodyText(DESCRIPTIONS[2] + DESCRIPTIONS[4]);
                         //SlimeboundMod.logger.info("fight");
+                        logMetric(ID, "Fought Captured Player");
                         downfallMod.overrideBossDifficulty = true;
                         String s = downfallMod.possEncounterList.remove(AbstractDungeon.cardRandomRng.random(downfallMod.possEncounterList.size()-1));
                         switch (s) {
@@ -114,6 +116,7 @@ public class Colosseum_Evil extends AbstractImageEvent {
                         this.imageEventText.updateBodyText(DESCRIPTIONS[5]);
                         this.imageEventText.clearAllDialogs();
                         this.imageEventText.setDialogOption(OPTIONS[2]);
+                        logMetricIgnored(ID);
                         return;
                     default:
                         return;

--- a/src/main/java/downfall/events/CouncilOfGhosts_Evil.java
+++ b/src/main/java/downfall/events/CouncilOfGhosts_Evil.java
@@ -11,6 +11,7 @@ import com.megacrit.cardcrawl.localization.EventStrings;
 import com.megacrit.cardcrawl.vfx.cardManip.ShowCardAndObtainEffect;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 public class CouncilOfGhosts_Evil extends AbstractImageEvent {
@@ -40,7 +41,7 @@ public class CouncilOfGhosts_Evil extends AbstractImageEvent {
 
     private int screenNum = 0;
     private int hpLoss = 0;
-    private int goldCost = 200;
+    private int goldCost = 150;
 
     public CouncilOfGhosts_Evil() {
         super(NAME, DESCRIPTIONSALT[0], "images/events/ghost.jpg");
@@ -82,9 +83,11 @@ public class CouncilOfGhosts_Evil extends AbstractImageEvent {
                         this.imageEventText.updateBodyText(DESCRIPTIONSALT[1]);
                         AbstractDungeon.effectList.add(new ShowCardAndObtainEffect(new Apparition(), (float) Settings.WIDTH / 2.0F, (float) Settings.HEIGHT / 2.0F));
                         this.screenNum = 1;
-                        AbstractDungeon.player.loseGold(150);
+                        AbstractDungeon.player.loseGold(goldCost);
                         this.imageEventText.updateDialogOption(0, OPTIONS[5]);
                         this.imageEventText.clearRemainingOptions();
+                        logMetric(ID, "Purchased Apparition", Collections.singletonList(Apparition.ID), null, null, null, null, null, null,
+                                0, 0, 0, 0, 0, goldCost);
                         return;
                     case 1:
                         this.imageEventText.updateBodyText(ACCEPT_BODY);
@@ -95,7 +98,7 @@ public class CouncilOfGhosts_Evil extends AbstractImageEvent {
                         this.imageEventText.clearRemainingOptions();
                         return;
                     case 2:
-                        logMetricIgnored("Ghosts");
+                        logMetricIgnored(ID);
                         this.imageEventText.updateBodyText(EXIT_BODY);
                         this.screenNum = 2;
                         this.imageEventText.updateDialogOption(0, OPTIONS[5]);
@@ -121,6 +124,6 @@ public class CouncilOfGhosts_Evil extends AbstractImageEvent {
             AbstractDungeon.effectList.add(new ShowCardAndObtainEffect(c, (float) Settings.WIDTH / 2.0F, (float) Settings.HEIGHT / 2.0F));
         }
 
-        logMetricObtainCardsLoseMapHP("Ghosts", "Became a Ghost", cards, this.hpLoss);
+        logMetricObtainCardsLoseMapHP(ID, "Became a Ghost", cards, this.hpLoss);
     }
 }

--- a/src/main/java/downfall/events/CursedFountain.java
+++ b/src/main/java/downfall/events/CursedFountain.java
@@ -13,6 +13,8 @@ import downfall.downfallMod;
 import downfall.potions.CursedFountainPotion;
 import gremlin.characters.GremlinCharacter;
 
+import java.util.Collections;
+
 public class CursedFountain extends AbstractImageEvent {
     public static final String ID = "downfall:CursedFountain";
     public static final String NAME;
@@ -81,6 +83,9 @@ public class CursedFountain extends AbstractImageEvent {
                         AbstractDungeon.getCurrRoom().rewards.clear();
                         AbstractDungeon.getCurrRoom().rewards.add(new RewardItem(new CursedFountainPotion()));
                         AbstractDungeon.combatRewardScreen.open();
+                        logMetric(ID, "Bottle", null, null, null, null,
+                                null, Collections.singletonList(CursedFountainPotion.POTION_ID), null,
+                                0, 0, 0, 0, 0, 0);
                         return;
                     case 1:
                         //consume
@@ -88,6 +93,7 @@ public class CursedFountain extends AbstractImageEvent {
                         this.imageEventText.updateDialogOption(1, OPTIONS[6], true);
                         AbstractDungeon.effectList.add(new RainingGoldEffect(this.goldAmt));
                         AbstractDungeon.player.gainGold(this.goldAmt);
+                        logMetricGainGold(ID, "Consume", goldAmt);
                         return;
                     case 2:
                         //drink
@@ -97,12 +103,14 @@ public class CursedFountain extends AbstractImageEvent {
                         if (AbstractDungeon.player instanceof GremlinCharacter) {
                             ((GremlinCharacter)AbstractDungeon.player).healGremlins(AbstractDungeon.player.maxHealth);
                         }
+                        logMetricHeal(ID, "Drink", AbstractDungeon.player.maxHealth);
                         return;
                     case 3:
                         this.imageEventText.updateBodyText(DESCRIPTIONS[4]);
                         this.imageEventText.clearAllDialogs();
                         this.imageEventText.setDialogOption(OPTIONS[7]);
                         this.screenNum = 1;
+                        logMetricIgnored(ID);
                         return;
                 }
             default:

--- a/src/main/java/downfall/events/CursedFountain.java
+++ b/src/main/java/downfall/events/CursedFountain.java
@@ -99,11 +99,11 @@ public class CursedFountain extends AbstractImageEvent {
                         //drink
                         this.imageEventText.updateBodyText(DESCRIPTIONS[3]);
                         this.imageEventText.updateDialogOption(2, OPTIONS[6], true);
+                        logMetricHeal(ID, "Drink", AbstractDungeon.player.maxHealth - AbstractDungeon.player.currentHealth);
                         AbstractDungeon.player.heal(AbstractDungeon.player.maxHealth);
                         if (AbstractDungeon.player instanceof GremlinCharacter) {
                             ((GremlinCharacter)AbstractDungeon.player).healGremlins(AbstractDungeon.player.maxHealth);
                         }
-                        logMetricHeal(ID, "Drink", AbstractDungeon.player.maxHealth);
                         return;
                     case 3:
                         this.imageEventText.updateBodyText(DESCRIPTIONS[4]);

--- a/src/main/java/downfall/events/CursedTome_Evil.java
+++ b/src/main/java/downfall/events/CursedTome_Evil.java
@@ -52,6 +52,7 @@ public class CursedTome_Evil extends AbstractImageEvent {
                     CardCrawlGame.sound.play("EVENT_TOME");
                     this.imageEventText.clearAllDialogs();
                     AbstractDungeon.player.damage(new DamageInfo(null, this.finalDmg, DamageType.HP_LOSS));
+                    logMetricTakeDamage(ID, "Obtained Book", finalDmg);
                     this.imageEventText.setDialogOption(OPTIONS[7]);
                     this.imageEventText.updateBodyText(DESCRIPTIONS[1]);
                     this.screen = CurScreen.END;
@@ -62,6 +63,7 @@ public class CursedTome_Evil extends AbstractImageEvent {
                     this.imageEventText.setDialogOption(OPTIONS[7]);
                     this.imageEventText.updateBodyText(CardCrawlGame.languagePack.getEventString("Cursed Tome").DESCRIPTIONS[6]);
                     this.screen = CurScreen.END;
+                    logMetricIgnored(ID);
                     return;
                 }
 

--- a/src/main/java/downfall/events/DeadGuy_Evil.java
+++ b/src/main/java/downfall/events/DeadGuy_Evil.java
@@ -48,6 +48,8 @@ public class DeadGuy_Evil extends AbstractEvent {
     private int enemy;
     private DeadGuy_Evil.CUR_SCREEN screen;
     private Texture adventurerImg;
+    private int goldRewardMetric = 0;
+    private AbstractRelic relicRewardMetric = null;
 
     public DeadGuy_Evil() {
         this.x = 800.0F * Settings.scale;
@@ -139,10 +141,8 @@ public class DeadGuy_Evil extends AbstractEvent {
                 this.openMap();
                 break;
             case FAIL:
-                Iterator var2 = this.rewards.iterator();
 
-                while (var2.hasNext()) {
-                    String s = (String) var2.next();
+                for (String s : this.rewards) {
                     if (s.equals("GOLD")) {
                         AbstractDungeon.getCurrRoom().addGoldToRewards(30);
                     } else if (s.equals("RELIC")) {
@@ -153,10 +153,10 @@ public class DeadGuy_Evil extends AbstractEvent {
                 this.enterCombat();
                 AbstractDungeon.lastCombatMetricKey = this.getMonster();
                 ++this.numRewards;
-
+                logMetric(this.numRewards);
                 break;
             case ESCAPE:
-
+                logMetric(this.numRewards);
                 this.openMap();
                 break;
             default:
@@ -179,37 +179,22 @@ public class DeadGuy_Evil extends AbstractEvent {
     private void randomReward() {
         ++this.numRewards;
         this.encounterChance += 25;
-        String var1 = this.rewards.remove(0);
-        byte var2 = -1;
-        switch (var1.hashCode()) {
-            case -1447660627:
-                if (var1.equals("NOTHING")) {
-                    var2 = 1;
-                }
-                break;
-            case 2193504:
-                if (var1.equals("GOLD")) {
-                    var2 = 0;
-                }
-                break;
-            case 77859667:
-                if (var1.equals("RELIC")) {
-                    var2 = 2;
-                }
-        }
 
-        switch (var2) {
-            case 0:
+        switch (this.rewards.remove(0)) {
+            case "GOLD":
                 this.roomEventText.updateBodyText(DESCRIPTIONS[7]);
                 EffectHelper.gainGold(AbstractDungeon.player, this.x, this.y, 30);
                 AbstractDungeon.player.gainGold(30);
+                this.goldRewardMetric = 30;
+
                 break;
-            case 1:
+            case "NOTHING":
                 this.roomEventText.updateBodyText(DESCRIPTIONS[8]);
                 break;
-            case 2:
+            case "RELIC":
                 this.roomEventText.updateBodyText(DESCRIPTIONS[9]);
                 AbstractRelic r = AbstractDungeon.returnRandomScreenlessRelic(AbstractDungeon.returnRandomRelicTier());
+                this.relicRewardMetric = r;
                 AbstractDungeon.getCurrRoom().spawnRelicAndObtain(this.x, this.y, r);
                 break;
             default:
@@ -217,11 +202,11 @@ public class DeadGuy_Evil extends AbstractEvent {
         }
 
         if (this.numRewards == 3) {
+            logMetric(this.numRewards);
             this.roomEventText.updateBodyText(DESCRIPTIONS[10]);
             this.roomEventText.updateDialogOption(0, OPTIONS[1]);
             this.roomEventText.removeDialogOption(1);
             this.screen = DeadGuy_Evil.CUR_SCREEN.SUCCESS;
-
         } else {
 
             this.roomEventText.updateDialogOption(0, OPTIONS[3] + this.encounterChance + OPTIONS[4]);
@@ -230,7 +215,15 @@ public class DeadGuy_Evil extends AbstractEvent {
         }
 
     }
+    public void logMetric(int numAttempts) {
+        if (this.relicRewardMetric != null) {
+            AbstractEvent.logMetricGainGoldAndRelic(ID, "Searched '" + numAttempts + "' times", this.relicRewardMetric, this.goldRewardMetric);
 
+        } else {
+
+            AbstractEvent.logMetricGainGold(ID, "Searched '" + numAttempts + "' times", this.goldRewardMetric);
+        }
+    }
     public void render(SpriteBatch sb) {
         super.render(sb);
         sb.setColor(Color.WHITE);

--- a/src/main/java/downfall/events/Designer_Evil.java
+++ b/src/main/java/downfall/events/Designer_Evil.java
@@ -72,7 +72,7 @@ public class Designer_Evil extends AbstractImageEvent {
         super.update();
         if (this.option != OptionChosen.NONE) {
             AbstractCard c;
-            AbstractCard upgradeCard;
+            AbstractCard upgradeCard = null;
             switch (this.option) {
                 case REMOVE:
                     if (!AbstractDungeon.isScreenUp && !AbstractDungeon.gridSelectScreen.selectedCards.isEmpty()) {
@@ -82,6 +82,9 @@ public class Designer_Evil extends AbstractImageEvent {
                         AbstractDungeon.player.masterDeck.removeCard(upgradeCard);
                         AbstractDungeon.gridSelectScreen.selectedCards.clear();
                         this.option = OptionChosen.NONE;
+                        logMetric(ID, "Clean Up", null, Collections.singletonList(upgradeCard.cardID), null, null, null, null, null,
+                                hpLoss, 0, 0, 0, 0, 0);
+
                     }
                     break;
                 case REMOVE_AND_UPGRADE:
@@ -102,14 +105,19 @@ public class Designer_Evil extends AbstractImageEvent {
                         }
 
                         Collections.shuffle(upgradableCards, new Random(AbstractDungeon.miscRng.randomLong()));
+
                         if (!upgradableCards.isEmpty()) {
                             upgradeCard = upgradableCards.get(0);
                             upgradeCard.upgrade();
                             AbstractDungeon.player.bottledCardUpgradeCheck(upgradeCard);
                             AbstractDungeon.topLevelEffects.add(new ShowCardBrieflyEffect(upgradeCard.makeStatEquivalentCopy()));
                             AbstractDungeon.topLevelEffects.add(new UpgradeShineEffect((float) Settings.WIDTH / 2.0F, (float) Settings.HEIGHT / 2.0F));
+
                         } else {
                         }
+                        logMetric(ID, "Full Service", null, Collections.singletonList(removeCard.cardID), null,
+                                upgradeCard == null ? null : Collections.singletonList(upgradeCard.cardID), null, null, null,
+                                hpLoss, 0, 0, 0, 0, 0);
 
                         this.option = OptionChosen.NONE;
                     }
@@ -138,11 +146,15 @@ public class Designer_Evil extends AbstractImageEvent {
                         } else {
                             c = AbstractDungeon.gridSelectScreen.selectedCards.get(0);
                             AbstractDungeon.player.masterDeck.removeCard(c);
+                            transCards.add(c.cardID);
                             AbstractDungeon.transformCard(c, false, AbstractDungeon.miscRng);
                             newCard1 = AbstractDungeon.getTransformedCard();
+                            obtainedCards.add(newCard1.cardID);
                             AbstractDungeon.effectsQueue.add(new ShowCardAndObtainEffect(newCard1, (float) Settings.WIDTH / 2.0F, (float) Settings.HEIGHT / 2.0F));
                             AbstractDungeon.gridSelectScreen.selectedCards.clear();
                         }
+                        logMetric(ID, "Clean Up", null, transCards, obtainedCards, null, null, null, null,
+                                hpLoss, 0, 0, 0, 0, 0);
 
                         this.option = OptionChosen.NONE;
                     }
@@ -151,10 +163,15 @@ public class Designer_Evil extends AbstractImageEvent {
                     if (!AbstractDungeon.isScreenUp && !AbstractDungeon.gridSelectScreen.selectedCards.isEmpty()) {
                         AbstractDungeon.gridSelectScreen.selectedCards.get(0).upgrade();
                         AbstractDungeon.player.bottledCardUpgradeCheck(AbstractDungeon.gridSelectScreen.selectedCards.get(0));
-                        AbstractDungeon.effectsQueue.add(new ShowCardBrieflyEffect(AbstractDungeon.gridSelectScreen.selectedCards.get(0).makeStatEquivalentCopy()));
+                        upgradeCard = AbstractDungeon.gridSelectScreen.selectedCards.get(0);
+                        AbstractDungeon.effectsQueue.add(new ShowCardBrieflyEffect(upgradeCard.makeStatEquivalentCopy()));
                         AbstractDungeon.topLevelEffects.add(new UpgradeShineEffect((float) Settings.WIDTH / 2.0F, (float) Settings.HEIGHT / 2.0F));
                         AbstractDungeon.gridSelectScreen.selectedCards.clear();
                         this.option = OptionChosen.NONE;
+                        logMetric(ID, "Adjustments", null, null, null,
+                                Collections.singletonList(upgradeCard.cardID), null, null, null,
+                                hpLoss, 0, 0, 0, 0, 0);
+
                     }
             }
         }
@@ -189,6 +206,7 @@ public class Designer_Evil extends AbstractImageEvent {
                         this.imageEventText.updateBodyText(DESC[2]);
                         this.imageEventText.setDialogOption(OPTIONS[14]);
                         this.curScreen = CurrentScreen.DONE;
+                        logMetricIgnored(ID);
                         break;
                 }
                 break;
@@ -240,7 +258,7 @@ public class Designer_Evil extends AbstractImageEvent {
                     case 3:
                         this.imageEventText.loadImage("images/events/designerPunched2.jpg");
                         this.imageEventText.updateBodyText(DESC[5]);
-                        logMetricTakeDamage("Designer", "Punched", this.hpLoss);
+                        logMetricTakeDamage(ID, "Punched", this.hpLoss);
                         CardCrawlGame.sound.play("BLUNT_FAST");
                 }
 
@@ -284,6 +302,8 @@ public class Designer_Evil extends AbstractImageEvent {
             AbstractDungeon.topLevelEffects.add(new ShowCardBrieflyEffect(upgradableCards.get(0).makeStatEquivalentCopy(), (float) Settings.WIDTH / 2.0F - AbstractCard.IMG_WIDTH / 2.0F - 20.0F * Settings.scale, (float) Settings.HEIGHT / 2.0F));
             AbstractDungeon.topLevelEffects.add(new ShowCardBrieflyEffect(upgradableCards.get(1).makeStatEquivalentCopy(), (float) Settings.WIDTH / 2.0F + AbstractCard.IMG_WIDTH / 2.0F + 20.0F * Settings.scale, (float) Settings.HEIGHT / 2.0F));
             AbstractDungeon.topLevelEffects.add(new UpgradeShineEffect((float) Settings.WIDTH / 2.0F, (float) Settings.HEIGHT / 2.0F));
+            logMetric(ID, "Adjustments", null, null, null, cards, null, null, null,
+                    hpLoss, 0, 0, 0, 0, 0);
         }
 
     }

--- a/src/main/java/downfall/events/Designer_Evil.java
+++ b/src/main/java/downfall/events/Designer_Evil.java
@@ -153,7 +153,7 @@ public class Designer_Evil extends AbstractImageEvent {
                             AbstractDungeon.effectsQueue.add(new ShowCardAndObtainEffect(newCard1, (float) Settings.WIDTH / 2.0F, (float) Settings.HEIGHT / 2.0F));
                             AbstractDungeon.gridSelectScreen.selectedCards.clear();
                         }
-                        logMetric(ID, "Clean Up", null, transCards, obtainedCards, null, null, null, null,
+                        logMetric(ID, "Clean Up", obtainedCards, null, transCards, null, null, null, null,
                                 hpLoss, 0, 0, 0, 0, 0);
 
                         this.option = OptionChosen.NONE;

--- a/src/main/java/downfall/events/FaceTrader_Evil.java
+++ b/src/main/java/downfall/events/FaceTrader_Evil.java
@@ -75,7 +75,7 @@ public class FaceTrader_Evil extends AbstractImageEvent {
             case MAIN:
                 switch (buttonPressed) {
                     case 0:
-
+                        logMetric(ID, "Fight");
                         this.screen = CurScreen.FIGHT;
                         //SlimeboundMod.logger.info("fight");
                         AbstractDungeon.getCurrRoom().monsters =  MonsterHelper.getEncounter("downfall:FaceTrader");
@@ -90,7 +90,7 @@ public class FaceTrader_Evil extends AbstractImageEvent {
                         break;
                     case 1:
                         AbstractRelic r = this.getRandomFace();
-                        logMetricObtainRelic("FaceTrader", "Trade", r);
+                        logMetricObtainRelic(ID, "Trade", r);
                         AbstractDungeon.getCurrRoom().spawnRelicAndObtain((float) Settings.WIDTH / 2.0F, (float) Settings.HEIGHT / 2.0F, r);
                         this.imageEventText.updateBodyText(DESCRIPTIONS[3]);
                         this.imageEventText.clearAllDialogs();
@@ -142,7 +142,7 @@ public class FaceTrader_Evil extends AbstractImageEvent {
     }
 
     public void logMetric(String actionTaken) {
-        AbstractEvent.logMetric("FaceTrader", actionTaken);
+        AbstractEvent.logMetric(ID, actionTaken);
     }
 
     private enum CurScreen {

--- a/src/main/java/downfall/events/ForgottenAltar_Evil.java
+++ b/src/main/java/downfall/events/ForgottenAltar_Evil.java
@@ -64,6 +64,7 @@ public class ForgottenAltar_Evil extends AbstractImageEvent {
                         this.imageEventText.setDialogOption(OPTIONSALT[5]);
                         CardCrawlGame.sound.play("HEAL_1");
                         this.screenNum = 1;
+                        logMetricHealAtCost(ID, "Offer Souls", goldCost, hpLoss + 10);
                         return;
                     case 1:
 
@@ -74,13 +75,14 @@ public class ForgottenAltar_Evil extends AbstractImageEvent {
                         AbstractDungeon.player.damage(new DamageInfo(null, this.hpLoss));
                         CardCrawlGame.sound.play("HEAL_3");
                         this.screenNum = 1;
-
+                        logMetricDamageAndMaxHPGain(ID, "Shed Blood", this.hpLoss, 5);
                         return;
                     case 2:
                         this.imageEventText.clearAllDialogs();
                         this.imageEventText.updateBodyText(DESCRIPTIONSALT[1]);
                         this.imageEventText.setDialogOption(OPTIONSALT[5]);
                         this.screenNum = 1;
+                        logMetricIgnored(ID);
                         return;
                     default:
                         return;

--- a/src/main/java/downfall/events/GoldenIdol_Evil.java
+++ b/src/main/java/downfall/events/GoldenIdol_Evil.java
@@ -82,11 +82,14 @@ public class GoldenIdol_Evil extends AbstractImageEvent {
                             this.imageEventText.updateBodyText(DESCRIPTIONS[2]);
                             AbstractDungeon.topLevelEffects.add(new PurgeCardEffect(this.strike, (float) (Settings.WIDTH / 2), (float) (Settings.HEIGHT / 2)));
                             AbstractDungeon.player.masterDeck.removeCard(strike);
+                            logMetricCardRemoval(ID, "Set Trap", strike);
+
                             trapAlreadySet = true;
                         } else {
                             this.imageEventText.updateBodyText(DESCRIPTIONS[3]);
                             AbstractDungeon.effectList.add(new RainingGoldEffect(this.gold));
                             AbstractDungeon.player.gainGold(this.gold);
+                            logMetricGainGold(ID, "Harvest", gold);
                             trapAlreadySet = false;
                         }
 
@@ -105,6 +108,7 @@ public class GoldenIdol_Evil extends AbstractImageEvent {
                         this.imageEventText.clearAllDialogs();
                         this.imageEventText.setDialogOption(OPTIONS[3]);
                         this.screen = CurScreen.RESULT;
+                        logMetricIgnored(ID);
                         return;
                     default:
                         return;

--- a/src/main/java/downfall/events/GoldenShrine_Evil.java
+++ b/src/main/java/downfall/events/GoldenShrine_Evil.java
@@ -73,7 +73,7 @@ public class GoldenShrine_Evil extends AbstractImageEvent {
                 switch (buttonPressed) {
                     case 0:
                         this.screen = CUR_SCREEN.COMPLETE;
-                        //logMetricGainGold("Golden Shrine", "Pray", this.goldAmt);
+                        logMetricGainGold(ID, "Pray", this.goldAmt);
                         this.imageEventText.updateBodyText(DIALOG_2);
                         this.imageEventText.updateDialogOption(0, OPTIONS[3]);
                         AbstractDungeon.effectList.add(new RainingGoldEffect(this.goldAmt));
@@ -83,7 +83,7 @@ public class GoldenShrine_Evil extends AbstractImageEvent {
                     case 1:
                         this.screen = CUR_SCREEN.COMPLETE;
                         AbstractCard curse = new Regret();
-                       // logMetricGainGoldAndCard("Golden Shrine", "Desecrate", curse, 275);
+                        logMetricGainGoldAndCard(ID, "Desecrate", curse, 275);
                         AbstractDungeon.effectList.add(new RainingGoldEffect(275));
                         AbstractDungeon.player.gainGold(275);
                         AbstractDungeon.effectList.add(new ShowCardAndObtainEffect(curse, (float) Settings.WIDTH / 2.0F, (float) Settings.HEIGHT / 2.0F));
@@ -93,7 +93,7 @@ public class GoldenShrine_Evil extends AbstractImageEvent {
                         return;
                     case 2:
                         this.screen = CUR_SCREEN.COMPLETE;
-                      //  logMetricIgnored("Golden Shrine");
+                        logMetricIgnored(ID);
                         this.imageEventText.updateBodyText(IGNORE);
                         this.imageEventText.updateDialogOption(0, OPTIONS[3]);
                         this.imageEventText.clearRemainingOptions();

--- a/src/main/java/downfall/events/GremlinMatchGame_Evil.java
+++ b/src/main/java/downfall/events/GremlinMatchGame_Evil.java
@@ -309,6 +309,7 @@ public class GremlinMatchGame_Evil extends AbstractImageEvent {
                 switch (buttonPressed) {
                     case 0:
                         //SlimeboundMod.logger.info("case default opening map");
+                        logMetricObtainCards(ID, this.cardsMatched + " cards matched", this.matchedCards);
                         this.openMap();
                         return;
 
@@ -348,6 +349,7 @@ public class GremlinMatchGame_Evil extends AbstractImageEvent {
                         } else {
                             this.screen = CUR_SCREEN.FIGHT;
                             //SlimeboundMod.logger.info("fight");
+                            logMetric(ID, "Fight");
                             MonsterGroup monsters = new MonsterGroup(new GremlinFat(-400F, 0F));
                             monsters.add(new GremlinNob(0F, 0F));
                             AbstractDungeon.getCurrRoom().monsters = monsters;
@@ -358,6 +360,7 @@ public class GremlinMatchGame_Evil extends AbstractImageEvent {
                             AbstractDungeon.getCurrRoom().addGoldToRewards(100);
 
                             AbstractDungeon.getCurrRoom().eliteTrigger = true;
+                            AbstractDungeon.lastCombatMetricKey = "Match Game Nob";
                             this.imageEventText.clearRemainingOptions();
                             this.enterCombatFromImage();
                             return;

--- a/src/main/java/downfall/events/GremlinWheelGame_Evil.java
+++ b/src/main/java/downfall/events/GremlinWheelGame_Evil.java
@@ -312,6 +312,7 @@ public class GremlinWheelGame_Evil extends AbstractImageEvent {
 
                         this.screen = GremlinWheelGame_Evil.CUR_SCREEN.FIGHT;
                         //SlimeboundMod.logger.info("fight");
+                        logMetric(ID, "Fight");
                         MonsterGroup monsters = new MonsterGroup(new GremlinThief(-400F, 0F));
                         monsters.add(new GremlinNob(0F, 0F));
                         AbstractDungeon.getCurrRoom().monsters = monsters;
@@ -326,6 +327,7 @@ public class GremlinWheelGame_Evil extends AbstractImageEvent {
                     }
                 }
             case POSTGREMLIN:
+                logMetric(ID, "Killed Gremlin");
                 AbstractDungeon.getCurrRoom().rewards.clear();
                 AbstractRelic relic = AbstractDungeon.returnRandomScreenlessRelic(AbstractDungeon.returnRandomRelicTier());
                 AbstractDungeon.getCurrRoom().addRelicToRewards(relic);
@@ -347,18 +349,18 @@ public class GremlinWheelGame_Evil extends AbstractImageEvent {
         switch (this.result) {
             case 0:
                 this.hasFocus = false;
-                logMetricGainGold("Wheel of Change", "Gold", this.goldAmount);
+                logMetricGainGold(ID, "Gold", this.goldAmount);
                 break;
             case 1:
                 AbstractDungeon.getCurrRoom().rewards.clear();
                 AbstractRelic r = AbstractDungeon.returnRandomScreenlessRelic(AbstractDungeon.returnRandomRelicTier());
                 AbstractDungeon.getCurrRoom().addRelicToRewards(r);
                 AbstractDungeon.combatRewardScreen.open();
-                logMetric("Wheel of Change", "Relic");
+                logMetric(ID, "Relic");
                 this.hasFocus = false;
                 break;
             case 2:
-                logMetricHeal("Wheel of Change", "Full Heal", AbstractDungeon.player.maxHealth - AbstractDungeon.player.currentHealth);
+                logMetricHeal(ID, "Full Heal", AbstractDungeon.player.maxHealth - AbstractDungeon.player.currentHealth);
                 AbstractDungeon.player.heal(AbstractDungeon.player.maxHealth);
                 if (AbstractDungeon.player instanceof GremlinCharacter) {
                     ((GremlinCharacter)AbstractDungeon.player).healGremlins(AbstractDungeon.player.maxHealth);
@@ -367,7 +369,7 @@ public class GremlinWheelGame_Evil extends AbstractImageEvent {
                 break;
             case 3:
                 AbstractCard curse = new Decay();
-                logMetricObtainCard("Wheel of Change", "Cursed", curse);
+                logMetricObtainCard(ID, "Cursed", curse);
                 AbstractDungeon.effectList.add(new ShowCardAndObtainEffect(curse, (float) Settings.WIDTH / 2.0F, (float) Settings.HEIGHT / 2.0F));
                 this.hasFocus = false;
                 break;
@@ -383,7 +385,6 @@ public class GremlinWheelGame_Evil extends AbstractImageEvent {
                     this.imageEventText.updateBodyText(DESCRIPTIONS[14]);
                     CardCrawlGame.sound.play("ATTACK_DAGGER_6");
                     CardCrawlGame.sound.play("BLOOD_SPLAT");
-                    logMetric("Wheel of Change", "Gremlins");
                     gremlinchosen = true;
                 } else {
                     this.imageEventText.updateBodyText(DESCRIPTIONS[7]);
@@ -391,7 +392,7 @@ public class GremlinWheelGame_Evil extends AbstractImageEvent {
                     CardCrawlGame.sound.play("BLOOD_SPLAT");
                     int damageAmount = (int) ((float) AbstractDungeon.player.maxHealth * this.hpLossPercent);
                     AbstractDungeon.player.damage(new DamageInfo(null, damageAmount, DamageType.HP_LOSS));
-                    logMetricTakeDamage("Wheel of Change", "Damaged", damageAmount);
+                    logMetricTakeDamage(ID, "Damaged", damageAmount);
 
                 }
         }
@@ -401,7 +402,7 @@ public class GremlinWheelGame_Evil extends AbstractImageEvent {
     private void purgeLogic() {
         if (this.purgeResult && !AbstractDungeon.isScreenUp && !AbstractDungeon.gridSelectScreen.selectedCards.isEmpty()) {
             AbstractCard c = AbstractDungeon.gridSelectScreen.selectedCards.get(0);
-            logMetricCardRemoval("Wheel of Change", "Card Removal", c);
+            logMetricCardRemoval(ID, "Card Removal", c);
             AbstractDungeon.player.masterDeck.removeCard(c);
             AbstractDungeon.effectList.add(new PurgeCardEffect(c));
             AbstractDungeon.gridSelectScreen.selectedCards.clear();

--- a/src/main/java/downfall/events/GremlinWheelGame_Rest.java
+++ b/src/main/java/downfall/events/GremlinWheelGame_Rest.java
@@ -322,24 +322,24 @@ public class GremlinWheelGame_Rest extends AbstractImageEvent {
         switch (this.result) {
             case 0:
                 this.hasFocus = false;
-                logMetricGainGold("Wheel of Change", "Gold", this.goldAmount);
+                logMetricGainGold(ID, "Gold", this.goldAmount);
                 break;
             case 1:
                 AbstractDungeon.getCurrRoom().rewards.clear();
                 AbstractRelic r = AbstractDungeon.returnRandomScreenlessRelic(AbstractDungeon.returnRandomRelicTier());
                 AbstractDungeon.getCurrRoom().addRelicToRewards(r);
                 AbstractDungeon.combatRewardScreen.open();
-                logMetric("Wheel of Change", "Relic");
+                logMetric(ID, "Relic");
                 this.hasFocus = false;
                 break;
             case 2:
-                logMetricHeal("Wheel of Change", "Full Heal", AbstractDungeon.player.maxHealth - AbstractDungeon.player.currentHealth);
+                logMetricHeal(ID, "Full Heal", AbstractDungeon.player.maxHealth - AbstractDungeon.player.currentHealth);
                 AbstractDungeon.player.heal(AbstractDungeon.player.maxHealth);
                 this.hasFocus = false;
                 break;
             case 3:
                 AbstractCard curse = new Decay();
-                logMetricObtainCard("Wheel of Change", "Cursed", curse);
+                logMetricObtainCard(ID, "Cursed", curse);
                 AbstractDungeon.effectList.add(new ShowCardAndObtainEffect(curse, (float) Settings.WIDTH / 2.0F, (float) Settings.HEIGHT / 2.0F));
                 this.hasFocus = false;
                 break;
@@ -356,7 +356,7 @@ public class GremlinWheelGame_Rest extends AbstractImageEvent {
                 CardCrawlGame.sound.play("BLOOD_SPLAT");
                 int damageAmount = (int) ((float) AbstractDungeon.player.maxHealth * this.hpLossPercent);
                 AbstractDungeon.player.damage(new DamageInfo(null, damageAmount, DamageType.HP_LOSS));
-                logMetricTakeDamage("Wheel of Change", "Damaged", damageAmount);
+                logMetricTakeDamage(ID, "Damaged", damageAmount);
         }
 
     }
@@ -364,7 +364,7 @@ public class GremlinWheelGame_Rest extends AbstractImageEvent {
     private void purgeLogic() {
         if (this.purgeResult && !AbstractDungeon.isScreenUp && !AbstractDungeon.gridSelectScreen.selectedCards.isEmpty()) {
             AbstractCard c = AbstractDungeon.gridSelectScreen.selectedCards.get(0);
-            logMetricCardRemoval("Wheel of Change", "Card Removal", c);
+            logMetricCardRemoval(ID, "Card Removal", c);
             AbstractDungeon.player.masterDeck.removeCard(c);
             AbstractDungeon.effectList.add(new PurgeCardEffect(c));
             AbstractDungeon.gridSelectScreen.selectedCards.clear();

--- a/src/main/java/downfall/events/Joust_Evil.java
+++ b/src/main/java/downfall/events/Joust_Evil.java
@@ -64,11 +64,15 @@ public class Joust_Evil extends AbstractImageEvent {
                     case 0:
                         this.joustTimer = 0.01F;// 97
                         if (AbstractDungeon.cardRandomRng.randomBoolean()) {
-                            AbstractDungeon.player.damage(new DamageInfo(null, (int) (AbstractDungeon.player.maxHealth * 0.3), DamageInfo.DamageType.HP_LOSS));
+                            int damage = (int) (AbstractDungeon.player.maxHealth * 0.3);
+                            AbstractDungeon.player.damage(new DamageInfo(null, damage, DamageInfo.DamageType.HP_LOSS));
+                            logMetricTakeDamage(ID, "Fought Strong Knight", damage);
                             imageEventText.updateBodyText(DESCRIPTIONSALT[1]);
                         } else {
-                            AbstractDungeon.effectList.add(new RainingGoldEffect(200));
-                            AbstractDungeon.player.gainGold(200);
+                            int gold = 200;
+                            AbstractDungeon.effectList.add(new RainingGoldEffect(gold));
+                            AbstractDungeon.player.gainGold(gold);
+                            logMetricGainGold(ID, "Killed Strong Knight", gold);
                             imageEventText.updateBodyText(DESCRIPTIONSALT[2]);
                         }
                         break;
@@ -76,17 +80,22 @@ public class Joust_Evil extends AbstractImageEvent {
                         this.joustTimer = 0.01F;// 97
                         int x = AbstractDungeon.cardRandomRng.random(100);
                         if (x < 25) {
-                            AbstractDungeon.player.damage(new DamageInfo(null, (int) (AbstractDungeon.player.maxHealth * 0.15), DamageInfo.DamageType.HP_LOSS));
+                            int damage = (int) (AbstractDungeon.player.maxHealth * 0.15);
+                            AbstractDungeon.player.damage(new DamageInfo(null, damage, DamageInfo.DamageType.HP_LOSS));
+                            logMetricTakeDamage(ID, "Fought Weak Knight", damage);
                             imageEventText.updateBodyText(DESCRIPTIONSALT[3]);
                         } else {
-                            AbstractDungeon.effectList.add(new RainingGoldEffect(100));
-                            AbstractDungeon.player.gainGold(100);
+                            int gold = 100;
+                            AbstractDungeon.effectList.add(new RainingGoldEffect(gold));
+                            AbstractDungeon.player.gainGold(gold);
+                            logMetricGainGold(ID, "Killed Weak Knight", gold);
                             imageEventText.updateBodyText(DESCRIPTIONSALT[4]);
                         }
                         break;
                     default:
                         this.imageEventText.updateDialogOption(0, OPTIONS[7]);// 75
                         this.imageEventText.clearRemainingOptions();// 76
+                        logMetricIgnored(ID);
                         this.openMap();// 77
                 }
                 this.imageEventText.updateDialogOption(0, OPTIONS[7]);

--- a/src/main/java/downfall/events/KnowingSkull_Evil.java
+++ b/src/main/java/downfall/events/KnowingSkull_Evil.java
@@ -45,10 +45,13 @@ public class KnowingSkull_Evil extends AbstractImageEvent {
                     case 0:
                         this.imageEventText.updateBodyText(DESC[1]);
                         AbstractDungeon.player.damage(new DamageInfo(null, takeCost, DamageInfo.DamageType.HP_LOSS));// 114
-                        AbstractDungeon.getCurrRoom().spawnRelicAndObtain(Settings.WIDTH / 2F, Settings.HEIGHT / 2F, new KnowingSkull());
+                        KnowingSkull relic = new KnowingSkull();
+                        AbstractDungeon.getCurrRoom().spawnRelicAndObtain(Settings.WIDTH / 2F, Settings.HEIGHT / 2F, relic);
+                        logMetricObtainRelicAndDamage(ID, "Took Skull", relic, takeCost);
                         break;
                     case 1:
                         this.imageEventText.updateBodyText(DESC[2]);
+                        logMetricIgnored(ID);
                         break;
                 }
 

--- a/src/main/java/downfall/events/LivingWall_Evil.java
+++ b/src/main/java/downfall/events/LivingWall_Evil.java
@@ -77,7 +77,7 @@ public class LivingWall_Evil extends AbstractImageEvent {
                 case FORGET:
                     CardCrawlGame.sound.play("CARD_EXHAUST");
                     AbstractDungeon.topLevelEffects.add(new PurgeCardEffect(AbstractDungeon.gridSelectScreen.selectedCards.get(0), (float) (Settings.WIDTH / 2), (float) (Settings.HEIGHT / 2)));
-                    AbstractEvent.logMetricCardRemoval("Living Wall", "Forget", AbstractDungeon.gridSelectScreen.selectedCards.get(0));
+                    AbstractEvent.logMetricCardRemoval(ID, "Forget", AbstractDungeon.gridSelectScreen.selectedCards.get(0));
                     AbstractDungeon.player.masterDeck.removeCard(AbstractDungeon.gridSelectScreen.selectedCards.get(0));
                     break;
                 case CHANGE:
@@ -86,13 +86,13 @@ public class LivingWall_Evil extends AbstractImageEvent {
                     AbstractDungeon.transformCard(c, false, AbstractDungeon.miscRng);
                     AbstractCard transCard = AbstractDungeon.getTransformedCard();
                     AbstractDungeon.effectList.add(new ShowCardAndObtainEffect(transCard, c.current_x, c.current_y));
-                    AbstractEvent.logMetricTransformCard("Living Wall", "Change", c, transCard);
+                    AbstractEvent.logMetricTransformCard(ID, "Change", c, transCard);
                     break;
                 case GROW:
                     AbstractDungeon.effectsQueue.add(new UpgradeShineEffect((float) Settings.WIDTH / 2.0F, (float) Settings.HEIGHT / 2.0F));
                     AbstractDungeon.gridSelectScreen.selectedCards.get(0).upgrade();
                     AbstractCard upgCard = AbstractDungeon.gridSelectScreen.selectedCards.get(0);
-                    AbstractEvent.logMetricCardUpgrade("Living Wall", "Grow", upgCard);
+                    AbstractEvent.logMetricCardUpgrade(ID, "Grow", upgCard);
                     AbstractDungeon.player.bottledCardUpgradeCheck(upgCard);
             }
 
@@ -130,6 +130,7 @@ public class LivingWall_Evil extends AbstractImageEvent {
 //                        MonsterGroup monsters =
                                 AbstractDungeon.getCurrRoom().monsters = MonsterHelper.getEncounter("downfall:Heads");
 //                        AbstractDungeon.getCurrRoom().monsters = monsters;
+                        logMetric(ID, "Fight");
                         AbstractDungeon.getCurrRoom().rewards.clear();
                         AbstractDungeon.getCurrRoom().addGoldToRewards(100);
                         AbstractDungeon.getCurrRoom().rewards.add(new RemoveCardReward());

--- a/src/main/java/downfall/events/Mausoleum_Evil.java
+++ b/src/main/java/downfall/events/Mausoleum_Evil.java
@@ -73,9 +73,12 @@ public class Mausoleum_Evil extends AbstractImageEvent {
                 switch (buttonPressed) {
                     case 0:
                         this.imageEventText.updateBodyText(DESCRIPTIONSALT[1]);
-                        AbstractDungeon.effectList.add(new ShowCardAndObtainEffect(new Haunted(), (float) (Settings.WIDTH / 2), (float) (Settings.HEIGHT / 2)));
-                        AbstractDungeon.effectList.add(new RainingGoldEffect(200));
-                        AbstractDungeon.player.gainGold(200);
+                        Haunted curse = new Haunted();
+                        AbstractDungeon.effectList.add(new ShowCardAndObtainEffect(curse, (float) (Settings.WIDTH / 2), (float) (Settings.HEIGHT / 2)));
+                        int gold = 200;
+                        AbstractDungeon.effectList.add(new RainingGoldEffect(gold));
+                        AbstractDungeon.player.gainGold(gold);
+                        logMetricGainGoldAndCard(ID, "Feasted", curse, gold);
                         this.imageEventText.loadImage(downfallMod.assetPath("images/events/mausoleumNoSpirit.png"));
                         break;
                     case 1:
@@ -95,6 +98,11 @@ public class Mausoleum_Evil extends AbstractImageEvent {
                         CardCrawlGame.screenShake.rumble(2.0F);
                         AbstractRelic r = AbstractDungeon.returnRandomScreenlessRelic(AbstractDungeon.returnRandomRelicTier());
                         AbstractDungeon.getCurrRoom().spawnRelicAndObtain((float) (Settings.WIDTH / 2), (float) (Settings.HEIGHT / 2), r);
+                        if(result) {
+                            logMetricObtainCardAndRelic(ID, "Opened", new Writhe(), r);
+                        } else {
+                            logMetricObtainRelic(ID, "Opened", r);
+                        }
                         break;
                     default:
                         this.imageEventText.updateBodyText(NOPE_RESULT);
@@ -105,6 +113,7 @@ public class Mausoleum_Evil extends AbstractImageEvent {
                 this.screen = CurScreen.RESULT;
                 break;
             default:
+                logMetricIgnored(ID);
                 this.openMap();
         }
 

--- a/src/main/java/downfall/events/MindBloom_Evil.java
+++ b/src/main/java/downfall/events/MindBloom_Evil.java
@@ -156,13 +156,13 @@ public class MindBloom_Evil extends AbstractImageEvent {
                         CardCrawlGame.music.fadeOutBGM();
                         CardCrawlGame.music.fadeOutTempBGM();
                         CardCrawlGame.music.playTempBgmInstantly("MINDBLOOM", true);
+                        logMetric(ID, "Fight Yourself");
                         break;
                     case 1:
                         this.imageEventText.updateBodyText(DESCRIPTIONSALT[2]);
                         this.screen = CurScreen.LEAVE;
                         int effectCount = 0;
                         List<String> upgradedCards = new ArrayList();
-                        List<String> obtainedRelic = new ArrayList();
 
                         for (AbstractCard c : AbstractDungeon.player.masterDeck.group) {
                             if (c.canUpgrade()) {
@@ -185,6 +185,7 @@ public class MindBloom_Evil extends AbstractImageEvent {
                         AbstractDungeon.player.loseRelic(HeartBlessingGreen.ID);
 
                         AbstractDungeon.player.decreaseMaxHealth(10);
+                        logMetricUpgradeCards(ID, "Upgrade", upgradedCards);
 
                         this.imageEventText.updateDialogOption(0, OPTIONS[4]);
                         break;
@@ -192,18 +193,21 @@ public class MindBloom_Evil extends AbstractImageEvent {
                         if (AbstractDungeon.floorNum % 50 <= 40) {
                             this.imageEventText.updateBodyText(DESCRIPTIONSALT[1]);
                             this.screen = CurScreen.LEAVE;
-                            List<String> cardsAdded = new ArrayList();
+                            List<String> cardsAdded = new ArrayList<>();
                             cardsAdded.add("Normality");
                             cardsAdded.add("Normality");
-                            AbstractDungeon.effectList.add(new RainingGoldEffect(999));
-                            AbstractDungeon.player.gainGold(999);
+                            int goldGain = 999;
+                            AbstractDungeon.effectList.add(new RainingGoldEffect(goldGain));
+                            AbstractDungeon.player.gainGold(goldGain);
                             AbstractDungeon.effectList.add(new ShowCardAndObtainEffect(new Normality(), (float) Settings.WIDTH * 0.6F, (float) Settings.HEIGHT / 2.0F));
                             AbstractDungeon.effectList.add(new ShowCardAndObtainEffect(new Normality(), (float) Settings.WIDTH * 0.3F, (float) Settings.HEIGHT / 2.0F));
                             this.imageEventText.updateDialogOption(0, OPTIONS[4]);
+                            logMetric(ID, "Gold", cardsAdded, null, null, null, null, null, null, 0, 0, 0, 0, goldGain, 0);
                         } else {
                             this.imageEventText.updateBodyText(DESCRIPTIONSALT[1]);
                             this.screen = CurScreen.LEAVE;
                             AbstractCard curse = new Doubt();
+                            logMetricObtainCardAndHeal(ID, "Heal", curse, AbstractDungeon.player.maxHealth - AbstractDungeon.player.currentHealth);
                             AbstractDungeon.player.heal(AbstractDungeon.player.maxHealth);
                             AbstractDungeon.effectList.add(new ShowCardAndObtainEffect(curse, (float) Settings.WIDTH / 2.0F, (float) Settings.HEIGHT / 2.0F));
                             this.imageEventText.updateDialogOption(0, OPTIONS[4]);

--- a/src/main/java/downfall/events/MoaiHead_Evil.java
+++ b/src/main/java/downfall/events/MoaiHead_Evil.java
@@ -64,7 +64,7 @@ public class MoaiHead_Evil extends AbstractImageEvent {
                         if (AbstractDungeon.player.maxHealth < 1) {
                             AbstractDungeon.player.maxHealth = 1;
                         }
-
+                        logMetricHealAndLoseMaxHP(ID, "Heal", AbstractDungeon.player.maxHealth - AbstractDungeon.player.currentHealth, hpAmt);
                         AbstractDungeon.player.heal(AbstractDungeon.player.maxHealth);
                         if (AbstractDungeon.player instanceof GremlinCharacter) {
                             ((GremlinCharacter)AbstractDungeon.player).healGremlins(AbstractDungeon.player.maxHealth);
@@ -78,6 +78,8 @@ public class MoaiHead_Evil extends AbstractImageEvent {
                         this.screenNum = 1;
                         AbstractDungeon.player.loseGold(this.goldAmount);
                         AbstractDungeon.player.increaseMaxHp(this.hpAmt, false);
+                        logMetric(ID, "Gave Souls", null, null, null, null, null, null, null,
+                                0, AbstractDungeon.player.maxHealth - AbstractDungeon.player.currentHealth, 0, hpAmt, goldAmount, 0);
                         AbstractDungeon.player.heal(AbstractDungeon.player.maxHealth);
                         if (AbstractDungeon.player instanceof GremlinCharacter) {
                             ((GremlinCharacter)AbstractDungeon.player).healGremlins(AbstractDungeon.player.maxHealth);
@@ -90,6 +92,7 @@ public class MoaiHead_Evil extends AbstractImageEvent {
                         this.screenNum = 1;
                         this.imageEventText.updateDialogOption(0, OPTIONS[4]);
                         this.imageEventText.clearRemainingOptions();
+                        logMetricIgnored(ID);
                         return;
                 }
             default:

--- a/src/main/java/downfall/events/Nloth_Evil.java
+++ b/src/main/java/downfall/events/Nloth_Evil.java
@@ -83,6 +83,7 @@ public class Nloth_Evil extends AbstractImageEvent {
                         this.screenNum = 1;
                         this.imageEventText.updateDialogOption(0, OPTIONS[2]);
                         this.imageEventText.clearRemainingOptions();
+                        logMetricRelicSwap(ID, "Traded Relic", gift, choice1);
                         return;
                     case 1:
                         this.imageEventText.updateBodyText(DIALOG_2);
@@ -97,18 +98,16 @@ public class Nloth_Evil extends AbstractImageEvent {
                         this.screenNum = 1;
                         this.imageEventText.updateDialogOption(0, OPTIONS[2]);
                         this.imageEventText.clearRemainingOptions();
+                        logMetricRelicSwap(ID, "Traded Relic", gift, choice2);
                         return;
                     case 2:
                         this.imageEventText.updateBodyText(DESCRIPTIONSALT[0]);
-                        AbstractDungeon.effectList.add(new ShowCardAndObtainEffect(new Pain(), (float) Settings.WIDTH / 2.0F, (float) Settings.HEIGHT / 2.0F));
-                        AbstractDungeon.getCurrRoom().spawnRelicAndObtain((float) (Settings.WIDTH / 2), (float) (Settings.HEIGHT / 2), AbstractDungeon.returnRandomRelic(AbstractDungeon.returnRandomRelicTier()));
+                        Pain curse = new Pain();
+                        AbstractDungeon.effectList.add(new ShowCardAndObtainEffect(curse, (float) Settings.WIDTH / 2.0F, (float) Settings.HEIGHT / 2.0F));
+                        AbstractRelic relic = AbstractDungeon.returnRandomRelic(AbstractDungeon.returnRandomRelicTier());
+                        AbstractDungeon.getCurrRoom().spawnRelicAndObtain((float) (Settings.WIDTH / 2), (float) (Settings.HEIGHT / 2), relic);
                         CardCrawlGame.sound.play("BLUNT_HEAVY");
-                        this.screenNum = 1;
-                        this.imageEventText.updateDialogOption(0, OPTIONS[2]);
-                        this.imageEventText.clearRemainingOptions();
-                        return;
-                    case 3:
-                        this.imageEventText.updateBodyText(DIALOG_3);
+                        logMetricObtainCardAndRelic(ID, "Punch", curse, relic);
                         this.screenNum = 1;
                         this.imageEventText.updateDialogOption(0, OPTIONS[2]);
                         this.imageEventText.clearRemainingOptions();
@@ -118,6 +117,7 @@ public class Nloth_Evil extends AbstractImageEvent {
                         this.screenNum = 1;
                         this.imageEventText.updateDialogOption(0, OPTIONS[2]);
                         this.imageEventText.clearRemainingOptions();
+                        logMetricIgnored(ID);
                         return;
                 }
             case 1:

--- a/src/main/java/downfall/events/Portal_Evil.java
+++ b/src/main/java/downfall/events/Portal_Evil.java
@@ -48,16 +48,18 @@ public class Portal_Evil extends AbstractImageEvent {
 
                         this.imageEventText.updateBodyText(DESCRIPTIONSALT[1]);
                         this.screen = CurScreen.LEAVE;
-                        AbstractDungeon.getCurrRoom().spawnRelicAndObtain((float) Settings.WIDTH / 2.0F, (float) Settings.HEIGHT / 2.0F, new TeleportStone());
+                        TeleportStone relic = new TeleportStone();
+                        AbstractDungeon.getCurrRoom().spawnRelicAndObtain((float) Settings.WIDTH / 2.0F, (float) Settings.HEIGHT / 2.0F, relic);
 
                         CardCrawlGame.sound.play("ATTACK_MAGIC_SLOW_1");
                         this.imageEventText.updateDialogOption(0, OPTIONS[1]);
-
+                        logMetricObtainRelic(ID, "Took Portal Stone", relic);
                         break;
                     case 1:
                         this.imageEventText.updateBodyText(DIALOG_3);
                         this.screen = CurScreen.LEAVE;
                         this.imageEventText.updateDialogOption(0, OPTIONS[1]);
+                        logMetricIgnored(ID);
                         break;
                 }
 

--- a/src/main/java/downfall/events/SensoryStone_Evil.java
+++ b/src/main/java/downfall/events/SensoryStone_Evil.java
@@ -66,6 +66,7 @@ public class SensoryStone_Evil extends AbstractImageEvent {
             case INTRO_2:
                 switch(buttonPressed) {
                     case 0:
+                        logMetric(ID, "Memory 1");
                         this.screen = CurScreen.ACCEPT;
                         this.choice = 1;
                         this.reward(this.choice);
@@ -73,6 +74,7 @@ public class SensoryStone_Evil extends AbstractImageEvent {
                         getMemoryText();
                         break;
                     case 1:
+                        logMetricTakeDamage(ID, "Memory 2", 5);
                         this.screen = CurScreen.ACCEPT;
                         this.choice = 2;
                         this.reward(this.choice);
@@ -81,6 +83,7 @@ public class SensoryStone_Evil extends AbstractImageEvent {
                         getMemoryText();
                         break;
                     case 2:
+                        logMetricTakeDamage(ID, "Memory 3", 10);
                         this.screen = CurScreen.ACCEPT;
                         this.choice = 3;
                         this.reward(this.choice);

--- a/src/main/java/downfall/events/Serpent_Evil.java
+++ b/src/main/java/downfall/events/Serpent_Evil.java
@@ -6,6 +6,7 @@ import com.megacrit.cardcrawl.cards.curses.Doubt;
 import com.megacrit.cardcrawl.core.CardCrawlGame;
 import com.megacrit.cardcrawl.core.Settings;
 import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
+import com.megacrit.cardcrawl.events.AbstractEvent;
 import com.megacrit.cardcrawl.events.AbstractImageEvent;
 import com.megacrit.cardcrawl.helpers.CardLibrary;
 import com.megacrit.cardcrawl.localization.EventStrings;
@@ -76,11 +77,13 @@ public class Serpent_Evil extends AbstractImageEvent {
                     this.imageEventText.loadImage(downfallMod.assetPath("images/events/liarsGame2.png"));
 
                     this.screen = CUR_SCREEN.AGREE;
+                    AbstractEvent.logMetricGainGoldAndCard(ID, "Punch", this.curse, this.goldReward);
                 } else {
                     this.imageEventText.updateBodyText(DISAGREE_DIALOG);
                     this.imageEventText.removeDialogOption(1);
                     this.imageEventText.updateDialogOption(0, OPTIONS[3]);
                     this.screen = CUR_SCREEN.DISAGREE;
+                    AbstractEvent.logMetricIgnored(ID);
                 }
                 break;
             default:

--- a/src/main/java/downfall/events/ShiningLight_Evil.java
+++ b/src/main/java/downfall/events/ShiningLight_Evil.java
@@ -68,7 +68,6 @@ public class ShiningLight_Evil extends AbstractImageEvent {
                     this.imageEventText.removeDialogOption(1);
                     this.imageEventText.updateDialogOption(0, OPTIONS[1]);
                     this.screen = CUR_SCREEN.COMPLETE;
-                    AbstractDungeon.effectList.add(new ShowCardAndObtainEffect(new Malfunctioning(), (float) Settings.WIDTH * .5F + 10.0F * Settings.scale, (float) Settings.HEIGHT / 2.0F));
 
                     this.upgradeCards();
                 } else {
@@ -76,6 +75,7 @@ public class ShiningLight_Evil extends AbstractImageEvent {
                     this.imageEventText.removeDialogOption(1);
                     this.imageEventText.updateDialogOption(0, OPTIONS[1]);
                     this.screen = CUR_SCREEN.COMPLETE;
+                    logMetricIgnored(ID);
                 }
                 break;
             default:
@@ -129,6 +129,11 @@ public class ShiningLight_Evil extends AbstractImageEvent {
 
             }
         }
+
+        Malfunctioning curse = new Malfunctioning();
+        AbstractDungeon.effectList.add(new ShowCardAndObtainEffect(curse, (float) Settings.WIDTH * .5F + 10.0F * Settings.scale, (float) Settings.HEIGHT / 2.0F));
+        logMetric(ID, "Entered Light", Collections.singletonList(curse.cardID), null, null, cardMetrics, null, null, null,
+                0, 0, 0, 0, 0, 0);
 
     }
 

--- a/src/main/java/downfall/events/TheNest_Evil.java
+++ b/src/main/java/downfall/events/TheNest_Evil.java
@@ -63,6 +63,7 @@ public class TheNest_Evil extends AbstractImageEvent {
                         this.screen = CUR_SCREEN.GIFTSTAGE1;
                         return;
                     case 1:
+                        logMetricObtainCardAndDamage(ID, "Stole from Cult", dagger, 6);
                         this.imageEventText.updateBodyText(DESCRIPTIONS[1]);
                         AbstractDungeon.player.damage(new DamageInfo((AbstractCreature)null, 6, DamageInfo.DamageType.HP_LOSS));
 
@@ -75,7 +76,7 @@ public class TheNest_Evil extends AbstractImageEvent {
 
                         return;
                     case 2:
-
+                        logMetric(ID, "Accepted Cult Offering");
                         this.imageEventText.updateBodyText(DESCRIPTIONS[2]);
                         this.screen = CUR_SCREEN.COMPLETE;
                         AbstractDungeon.getCurrRoom().rewards.add(new RewardItem(PotionHelper.getPotion(CultistPotion.POTION_ID)));
@@ -88,6 +89,7 @@ public class TheNest_Evil extends AbstractImageEvent {
                 }
                 break;
             case GIFTSTAGE1:
+                logMetricObtainCard(ID, "Performed Ritual Sacrifice", dagger);
                 AbstractDungeon.effectList.add(new ShowCardAndObtainEffect(this.dagger, (float)Settings.WIDTH * 0.3F, (float)Settings.HEIGHT / 2.0F));
                 this.imageEventText.updateBodyText(DESCRIPTIONS[4]);
                 this.imageEventText.clearAllDialogs();

--- a/src/main/java/downfall/events/TombRedMask_Evil.java
+++ b/src/main/java/downfall/events/TombRedMask_Evil.java
@@ -15,6 +15,7 @@ import downfall.relics.RedIOU;
 import downfall.relics.RedIOUUpgrade;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Iterator;
 
 public class TombRedMask_Evil extends AbstractImageEvent {
@@ -83,6 +84,17 @@ public class TombRedMask_Evil extends AbstractImageEvent {
                     AbstractDungeon.player.loseRelic(RedIOU.ID);
                     AbstractDungeon.getCurrRoom().spawnRelicAndObtain((float)(Settings.WIDTH / 2), (float)(Settings.HEIGHT / 2), new RedIOUUpgrade());
 
+                    if(MaskTaken) {
+                        ArrayList<String> relics = new ArrayList<String>();
+                        relics.add(RedIOUUpgrade.ID);
+                        relics.add(RedMask.ID);
+
+                        logMetric(ID, "Broke Tomb and Upgraded Contract", null, Collections.singletonList(attack.cardID), null, null,
+                                relics, null, Collections.singletonList(RedIOU.ID),
+                                0, 0, 0, 0, 0, 0);
+                    } else {
+                        logMetricRelicSwap(ID, "Upgraded Contract", new RedIOU(), new RedIOUUpgrade());
+                    }
                     return;
                 } else if (buttonPressed == 1 && !MaskTaken) {
                     AbstractDungeon.effectList.add(new PurgeCardEffect(this.attack));
@@ -105,8 +117,10 @@ public class TombRedMask_Evil extends AbstractImageEvent {
                     this.imageEventText.setDialogOption(OPTIONS[5]);
                     if (!this.MaskTaken) {
                         this.imageEventText.updateBodyText(DESCRIPTIONS[3]);
+                        logMetricIgnored(ID);
                     } else {
                         this.imageEventText.updateBodyText(DESCRIPTIONS[4]);
+                        logMetricRemoveCardAndObtainRelic(ID, "Broke Tomb", attack, new RedMask());
                     }
                     this.screen = CurScreen.RESULT;
                     return;

--- a/src/main/java/downfall/events/Vagrant_Evil.java
+++ b/src/main/java/downfall/events/Vagrant_Evil.java
@@ -53,7 +53,9 @@ public class Vagrant_Evil extends AbstractImageEvent {
                 switch (buttonPressed) {
                     case 0:
                         AbstractDungeon.player.damage(new DamageInfo(null, takeCost, DamageInfo.DamageType.HP_LOSS));// 114
-                        AbstractDungeon.player.gainGold(85);
+                        int gold = 85;
+                        AbstractDungeon.player.gainGold(gold);
+                        logMetricGainGoldAndDamage(ID, "Punch", gold, takeCost);
                         this.imageEventText.updateBodyText(DESCRIPTIONSALT[0]);
                         this.screenNum = 1;
                         this.imageEventText.updateDialogOption(0, OPTIONS[5]);
@@ -63,7 +65,7 @@ public class Vagrant_Evil extends AbstractImageEvent {
                         this.imageEventText.updateBodyText(DESCRIPTIONSALT[1]);// 60
                         AbstractCard card = new PrideStandard();// 62
                         AbstractRelic relic = AbstractDungeon.returnRandomScreenlessRelic(AbstractDungeon.returnRandomRelicTier());// 63 64
-                        AbstractEvent.logMetricObtainCardAndRelic("Addict", "Stole Relic", card, relic);// 65
+                        AbstractEvent.logMetricObtainCardAndRelic(ID, "Stole Relic", card, relic);// 65
                         AbstractDungeon.effectList.add(new ShowCardAndObtainEffect(card, (float) (Settings.WIDTH / 2), (float) (Settings.HEIGHT / 2)));// 66
                         AbstractDungeon.getCurrRoom().spawnRelicAndObtain(this.drawX, this.drawY, relic);// 68
                         this.imageEventText.updateDialogOption(0, OPTIONS[5]);// 70
@@ -71,6 +73,7 @@ public class Vagrant_Evil extends AbstractImageEvent {
                         this.screenNum = 1;
                         return;// 73
                     default:
+                        logMetricIgnored(ID);
                         this.imageEventText.updateDialogOption(0, OPTIONS[5]);// 75
                         this.imageEventText.clearRemainingOptions();// 76
                         this.openMap();// 77

--- a/src/main/java/downfall/events/WeMeetAgain_Evil.java
+++ b/src/main/java/downfall/events/WeMeetAgain_Evil.java
@@ -121,6 +121,9 @@ public class WeMeetAgain_Evil extends AbstractImageEvent {
                             AbstractDungeon.getCurrRoom().rewards.add(new RewardItem(PotionHelper.getRandomPotion()));
                         }
                         AbstractDungeon.player.loseRelic(this.relicsOffered.get(0).relicId);
+                        logMetric(ID, "Traded Relic For Potions", null, null, null, null,
+                                null, null, Collections.singletonList(this.relicsOffered.get(0).relicId),
+                                0, 0, 0, 0, 0, 0);
 
                         AbstractDungeon.getCurrRoom().phase = AbstractRoom.RoomPhase.COMPLETE;
                         AbstractDungeon.combatRewardScreen.open();
@@ -131,6 +134,9 @@ public class WeMeetAgain_Evil extends AbstractImageEvent {
                         AbstractDungeon.effectList.add(new RainingGoldEffect(this.goldAmt));
                         AbstractDungeon.player.gainGold(this.goldAmt);
                         AbstractDungeon.player.loseRelic(this.relicsOffered.get(1).relicId);
+                        logMetric(ID, "Traded Relic For Gold", null, null, null, null,
+                                null, null, Collections.singletonList(this.relicsOffered.get(1).relicId),
+                                0, 0, 0, 0, goldAmt, 0);
 
                         break;
                     case 2:
@@ -138,12 +144,16 @@ public class WeMeetAgain_Evil extends AbstractImageEvent {
                         AbstractCard rewardCard = AbstractDungeon.getCard(AbstractCard.CardRarity.RARE).makeCopy();
                         AbstractDungeon.effectList.add(new ShowCardAndObtainEffect(rewardCard, Settings.WIDTH * 0.5F, Settings.HEIGHT * 0.2F));
                         AbstractDungeon.player.loseRelic(this.relicsOffered.get(2).relicId);
+                        logMetric(ID, "Traded Relic For Card", null, null, null, null,
+                                null, null, Collections.singletonList(this.relicsOffered.get(2).relicId),
+                                0, 0, 0, 0, 0, 0);
 
                         this.imageEventText.clearAllDialogs();
                         this.imageEventText.setDialogOption(OPTIONS[6]);
                         break;
                     case 3:
                         this.imageEventText.updateBodyText(DESCRIPTIONS[4]);
+                        logMetricIgnored(ID);
                 }
 
                 this.imageEventText.updateDialogOption(0, OPTIONS[6]);

--- a/src/main/java/downfall/events/WingStatue_Evil.java
+++ b/src/main/java/downfall/events/WingStatue_Evil.java
@@ -50,6 +50,7 @@ public class WingStatue_Evil extends AbstractImageEvent {
                         AbstractDungeon.player.damage(new DamageInfo(AbstractDungeon.player, this.damage));
                         AbstractDungeon.effectList.add(new FlashAtkImgEffect(AbstractDungeon.player.hb.cX, AbstractDungeon.player.hb.cY, AttackEffect.FIRE));
                         this.screen = CurScreen.RESULT;
+                        logMetricObtainRelicAndDamage(ID, "Destroyed Statue", new ShatteredFragment(), damage);
                         return;
                     case 1:
                         this.imageEventText.updateBodyText(DESCRIPTIONS[1]);
@@ -57,12 +58,14 @@ public class WingStatue_Evil extends AbstractImageEvent {
                         this.imageEventText.setDialogOption(OPTIONS[3]);
                         this.screen = CurScreen.RESULT;
                         AbstractDungeon.getCurrRoom().spawnRelicAndObtain((float) Settings.WIDTH / 2.0F, (float) Settings.HEIGHT / 2.0F, new BrokenWingStatue());
+                        logMetricObtainRelic(ID, "Collected Statue", new BrokenWingStatue());
                         return;
                     case 2:
                         this.imageEventText.updateBodyText(DESCRIPTIONS[3]);
                         this.imageEventText.clearAllDialogs();
                         this.imageEventText.setDialogOption(OPTIONS[3]);
                         this.screen = CurScreen.RESULT;
+                        logMetricIgnored(ID);
                         return;
                     default:
                         return;

--- a/src/main/java/downfall/events/WomanInBlue_Evil.java
+++ b/src/main/java/downfall/events/WomanInBlue_Evil.java
@@ -67,6 +67,7 @@ public class WomanInBlue_Evil extends AbstractImageEvent {
             case INTRO:
                 switch (buttonPressed) {
                     case 0:
+                        logMetric(ID, "Punch");
                         this.screen = WomanInBlue_Evil.CurScreen.FIGHT;
                         AbstractDungeon.getCurrRoom().monsters =  MonsterHelper.getEncounter(LadyInBlue.ID);
                         AbstractDungeon.getCurrRoom().rewards.clear();
@@ -126,10 +127,14 @@ public class WomanInBlue_Evil extends AbstractImageEvent {
                             this.imageEventText.updateBodyText(DESCRIPTIONS[2]);
                             CardCrawlGame.screenShake.shake(ShakeIntensity.MED, ShakeDur.MED, false);
                             CardCrawlGame.sound.play("BLUNT_FAST");
-                            AbstractDungeon.player.damage(new DamageInfo(null, MathUtils.ceil((float) AbstractDungeon.player.maxHealth * 0.05F), DamageType.HP_LOSS));
+                            int damage = MathUtils.ceil((float) AbstractDungeon.player.maxHealth * 0.05F);
+                            logMetricTakeDamage(ID, "Get Punched", damage);
+                            AbstractDungeon.player.damage(new DamageInfo(null, damage, DamageType.HP_LOSS));
                         } else {
                             this.imageEventText.updateBodyText(DESCRIPTIONS[1]);
+                            logMetricIgnored(ID);
                         }
+
                         break;
                     default:
                         this.imageEventText.clearRemainingOptions();

--- a/src/main/java/downfall/events/WorldOfGoop_Evil.java
+++ b/src/main/java/downfall/events/WorldOfGoop_Evil.java
@@ -10,6 +10,8 @@ import com.megacrit.cardcrawl.vfx.cardManip.ShowCardAndObtainEffect;
 import downfall.downfallMod;
 import downfall.cards.curses.Icky;
 
+import java.util.ArrayList;
+
 public class WorldOfGoop_Evil extends AbstractImageEvent {
     public static final String ID = downfallMod.makeID("WorldOfGoop");
     public static final String NAME;
@@ -55,6 +57,16 @@ public class WorldOfGoop_Evil extends AbstractImageEvent {
 
     }
 
+    private void logMetricGoop(int goops) {
+        ArrayList<String> icks = new ArrayList<>();
+        for (int i = 0; i < goops; i++) {
+            icks.add(Icky.ID);
+        }
+        logMetric(ID, "Gooped x"+goops, icks, null, null, null,
+                null, null, null,
+                0, 0, 0, 0, this.gold * goops, 0);
+    }
+
     protected void buttonEffect(int buttonPressed) {
         switch (this.screen) {
             case INTRO:
@@ -69,6 +81,7 @@ public class WorldOfGoop_Evil extends AbstractImageEvent {
                         AbstractDungeon.effectList.add(new ShowCardAndObtainEffect(new Icky(), (float) Settings.WIDTH * .75F + 10.0F * Settings.scale, (float) Settings.HEIGHT / 2.0F));
                         AbstractDungeon.effectList.add(new RainingGoldEffect(this.gold * 3));
                         AbstractDungeon.player.gainGold(this.gold * 3);
+                        logMetricGoop(3);
                         return;
                     case 1:
                         this.imageEventText.updateBodyText(GOLD_DIALOG);
@@ -79,6 +92,7 @@ public class WorldOfGoop_Evil extends AbstractImageEvent {
                         AbstractDungeon.effectList.add(new ShowCardAndObtainEffect(new Icky(), (float) Settings.WIDTH * .25F + 10.0F * Settings.scale, (float) Settings.HEIGHT / 2.0F));
                         AbstractDungeon.effectList.add(new RainingGoldEffect(this.gold * 2));
                         AbstractDungeon.player.gainGold(this.gold * 2);
+                        logMetricGoop(2);
                         return;
                     case 2:
                         this.imageEventText.updateBodyText(GOLD_DIALOG);
@@ -88,12 +102,14 @@ public class WorldOfGoop_Evil extends AbstractImageEvent {
                         AbstractDungeon.effectList.add(new ShowCardAndObtainEffect(new Icky(), (float) Settings.WIDTH * .5F + 10.0F * Settings.scale, (float) Settings.HEIGHT / 2.0F));
                         AbstractDungeon.effectList.add(new RainingGoldEffect(this.gold));
                         AbstractDungeon.player.gainGold(this.gold);
+                        logMetricGoop(1);
                         return;
                     case 3:
                         this.imageEventText.updateBodyText(LEAVE_DIALOG);
                         this.imageEventText.clearAllDialogs();
                         this.imageEventText.setDialogOption(OPTIONS[6]);
                         this.screen = CurScreen.RESULT;
+                        logMetricIgnored(ID);
                     default:
                         return;
                 }

--- a/src/main/java/downfall/events/shrines_evil/DuplicatorEvil.java
+++ b/src/main/java/downfall/events/shrines_evil/DuplicatorEvil.java
@@ -49,24 +49,31 @@ import downfall.downfallMod;
 
     public void update() {
         super.update();
-        if ((!AbstractDungeon.isScreenUp) && (!AbstractDungeon.gridSelectScreen.selectedCards.isEmpty()) &&
-                (!AbstractDungeon.gridSelectScreen.selectedCards.isEmpty())) {
-            AbstractCard c = ((AbstractCard) AbstractDungeon.gridSelectScreen.selectedCards.get(0)).makeStatEquivalentCopy();
+        if (!AbstractDungeon.isScreenUp && !AbstractDungeon.gridSelectScreen.selectedCards.isEmpty()) {
+            ArrayList<String> cards = new ArrayList<>();
+
+            AbstractCard c = AbstractDungeon.gridSelectScreen.selectedCards.get(0).makeStatEquivalentCopy();
             c.inBottleFlame = false;
             c.inBottleLightning = false;
             c.inBottleTornado = false;
             AbstractDungeon.effectList.add(new com.megacrit.cardcrawl.vfx.cardManip.ShowCardAndObtainEffect(c, com.megacrit.cardcrawl.core.Settings.WIDTH * 0.25F, com.megacrit.cardcrawl.core.Settings.HEIGHT / 2.0F));
+            cards.add(c.cardID);
 
             if (AbstractDungeon.gridSelectScreen.selectedCards.size() > 1){
-                c = ((AbstractCard) AbstractDungeon.gridSelectScreen.selectedCards.get(1)).makeStatEquivalentCopy();
+                c = AbstractDungeon.gridSelectScreen.selectedCards.get(1).makeStatEquivalentCopy();
                 c.inBottleFlame = false;
                 c.inBottleLightning = false;
                 c.inBottleTornado = false;
                 AbstractDungeon.effectList.add(new com.megacrit.cardcrawl.vfx.cardManip.ShowCardAndObtainEffect(c, com.megacrit.cardcrawl.core.Settings.WIDTH * 0.75F, com.megacrit.cardcrawl.core.Settings.HEIGHT / 2.0F));
+                cards.add(c.cardID);
 
-                AbstractDungeon.effectList.add(new ShowCardAndObtainEffect(CardLibrary.getCurse().makeStatEquivalentCopy(), (float) (Settings.WIDTH * .5F), (float) (Settings.HEIGHT / 2)));// 66
+                AbstractCard curse = CardLibrary.getCurse().makeStatEquivalentCopy();
+                cards.add(curse.cardID);
+                AbstractDungeon.effectList.add(new ShowCardAndObtainEffect(curse, (float) (Settings.WIDTH * .5F), (float) (Settings.HEIGHT / 2)));// 66
 
-
+                logMetricObtainCards(ID, "Desecrated", cards);
+            } else {
+                logMetricObtainCard(ID, "Copied", c);
             }
 
             AbstractDungeon.gridSelectScreen.selectedCards.clear();
@@ -97,6 +104,7 @@ import downfall.downfallMod;
                         this.imageEventText.updateBodyText(IGNORE);
                         this.imageEventText.updateDialogOption(0, OPTIONS[1]);
                         this.imageEventText.clearRemainingOptions();
+                        logMetricIgnored(ID);
                 }
 
                 break;

--- a/src/main/java/downfall/events/shrines_evil/PurificationShrineEvil.java
+++ b/src/main/java/downfall/events/shrines_evil/PurificationShrineEvil.java
@@ -12,6 +12,7 @@ import com.megacrit.cardcrawl.vfx.cardManip.ShowCardAndObtainEffect;
 import downfall.downfallMod;
 
 import java.util.ArrayList;
+import java.util.Collections;
 
 public class PurificationShrineEvil extends com.megacrit.cardcrawl.events.AbstractImageEvent {
     public static final String ID = downfallMod.makeID("Purifier");
@@ -51,6 +52,9 @@ public class PurificationShrineEvil extends com.megacrit.cardcrawl.events.Abstra
     public void update() {
         super.update();
         if ((!AbstractDungeon.isScreenUp) && (!AbstractDungeon.gridSelectScreen.selectedCards.isEmpty())) {
+            ArrayList<String> cards = new ArrayList<>();
+            cards.add(AbstractDungeon.gridSelectScreen.selectedCards.get(0).cardID);
+
             CardCrawlGame.sound.play("CARD_EXHAUST");
             AbstractDungeon.topLevelEffects.add(new com.megacrit.cardcrawl.vfx.cardManip.PurgeCardEffect(
 
@@ -65,16 +69,23 @@ public class PurificationShrineEvil extends com.megacrit.cardcrawl.events.Abstra
 
 
                 AbstractDungeon.player.masterDeck.removeCard((AbstractCard) AbstractDungeon.gridSelectScreen.selectedCards.get(1));
+                cards.add(AbstractDungeon.gridSelectScreen.selectedCards.get(1).cardID);
 
-            } if (AbstractDungeon.gridSelectScreen.selectedCards.size() > 2){
+            } else {
+                logMetricCardRemoval(ID, "Purged", (AbstractCard)AbstractDungeon.gridSelectScreen.selectedCards.get(0));
+            }
+
+            if (AbstractDungeon.gridSelectScreen.selectedCards.size() > 2){
                 AbstractDungeon.topLevelEffects.add(new com.megacrit.cardcrawl.vfx.cardManip.PurgeCardEffect(
 
                         (AbstractCard) AbstractDungeon.gridSelectScreen.selectedCards.get(2), com.megacrit.cardcrawl.core.Settings.WIDTH * 0.75F, com.megacrit.cardcrawl.core.Settings.HEIGHT / 2));
 
-                AbstractDungeon.effectList.add(new ShowCardAndObtainEffect(CardLibrary.getCurse().makeStatEquivalentCopy(), (float) (Settings.WIDTH * .5F), (float) (Settings.HEIGHT * .75F)));// 66
-
+                AbstractCard curse = CardLibrary.getCurse().makeStatEquivalentCopy();
+                AbstractDungeon.effectList.add(new ShowCardAndObtainEffect(curse, (float) (Settings.WIDTH * .5F), (float) (Settings.HEIGHT * .75F)));// 66
                 AbstractDungeon.player.masterDeck.removeCard((AbstractCard) AbstractDungeon.gridSelectScreen.selectedCards.get(2));
+                cards.add(AbstractDungeon.gridSelectScreen.selectedCards.get(2).cardID);
 
+                logMetric(ID, "Desecrated", Collections.singletonList(curse.cardID), cards, null, null, null, null, null, 0, 0, 0, 0, 0, 0);
             }
             AbstractDungeon.gridSelectScreen.selectedCards.clear();
 
@@ -112,6 +123,7 @@ public class PurificationShrineEvil extends com.megacrit.cardcrawl.events.Abstra
                         this.imageEventText.updateBodyText(IGNORE);
                         this.imageEventText.updateDialogOption(0, OPTIONS[1]);
                         this.imageEventText.clearRemainingOptions();
+                        logMetricIgnored(ID);
                 }
 
                 break;

--- a/src/main/java/downfall/patches/EventHelperEventNamePatch.java
+++ b/src/main/java/downfall/patches/EventHelperEventNamePatch.java
@@ -1,6 +1,7 @@
 package downfall.patches;
 
 
+import basemod.eventUtil.EventUtils;
 import com.evacipated.cardcrawl.modthespire.lib.SpirePatch;
 import com.evacipated.cardcrawl.modthespire.lib.SpirePostfixPatch;
 import com.evacipated.cardcrawl.modthespire.lib.SpirePrefixPatch;
@@ -23,11 +24,10 @@ public class EventHelperEventNamePatch {
             return __result;  // vanilla event name, use result
         }
 
-        AbstractEvent event = EventHelper.getEvent(key);
-        if (event == null) {
-            return key + " (event not found)";  // missing/changed/non-loaded event, return internal ID
+        Class<? extends AbstractEvent> cls = EventUtils.getEventClass(key);
+        if (cls == null) {
+            return key + " (event class not found)";  // missing/changed/non-loaded event, return internal ID
         }
-        Class<? extends AbstractEvent> cls = event.getClass();
 
         try {
             Field field = cls.getDeclaredField("NAME");

--- a/src/main/java/downfall/patches/EventHelperEventNamePatch.java
+++ b/src/main/java/downfall/patches/EventHelperEventNamePatch.java
@@ -1,0 +1,41 @@
+package downfall.patches;
+
+
+import com.evacipated.cardcrawl.modthespire.lib.SpirePatch;
+import com.evacipated.cardcrawl.modthespire.lib.SpirePostfixPatch;
+import com.evacipated.cardcrawl.modthespire.lib.SpirePrefixPatch;
+import com.evacipated.cardcrawl.modthespire.lib.SpireReturn;
+import com.megacrit.cardcrawl.events.AbstractEvent;
+import com.megacrit.cardcrawl.helpers.EventHelper;
+
+import java.lang.reflect.Field;
+
+@SpirePatch(
+        clz = EventHelper.class,
+        method = "getEventName"
+)
+public class EventHelperEventNamePatch {
+    @SpirePostfixPatch
+    static String getEventName(String __result, String key) {
+        // EventHelper.getEventName has a hardcoded switch/case containing every vanilla event and its localized name
+        // this patch attempts to use the NAME field of events to return the localized names for non-vanilla events.
+        if(!__result.equals("")) {
+            return __result;  // vanilla event name, use result
+        }
+
+        AbstractEvent event = EventHelper.getEvent(key);
+        if (event == null) {
+            return key + " (event not found)";  // missing/changed/non-loaded event, return internal ID
+        }
+        Class<? extends AbstractEvent> cls = event.getClass();
+
+        try {
+            Field field = cls.getDeclaredField("NAME");
+            String name = (String)field.get(null);
+            return name;
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            return key + " (NAME not found)";  // no NAME field, return internal ID
+        }
+
+    }
+}

--- a/src/main/java/downfall/util/BossCardReward.java
+++ b/src/main/java/downfall/util/BossCardReward.java
@@ -38,7 +38,11 @@ public class BossCardReward extends CustomReward {
         while (cardsList.size() < numCards) {
             AbstractCard q = getBossCard();
             if (!cardListDuplicate(cardsList, q) && q.rarity != AbstractCard.CardRarity.SPECIAL) {
-                cardsList.add(q.makeCopy());
+                q = q.makeCopy();
+                for (AbstractRelic r : AbstractDungeon.player.relics) {
+                    r.onPreviewObtainCard(q);
+                }
+                cardsList.add(q);
             }
         }
         return cardsList;

--- a/src/main/java/downfall/util/JaxReward.java
+++ b/src/main/java/downfall/util/JaxReward.java
@@ -6,6 +6,7 @@ import basemod.abstracts.CustomReward;
 import com.megacrit.cardcrawl.cards.colorless.JAX;
 import com.megacrit.cardcrawl.core.CardCrawlGame;
 import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
+import com.megacrit.cardcrawl.relics.AbstractRelic;
 import downfall.patches.RewardItemTypeEnumPatch;
 
 public class JaxReward extends CustomReward {
@@ -15,7 +16,11 @@ public class JaxReward extends CustomReward {
     public JaxReward() {
         super(TextureLoader.getTexture("downfallResources/images/rewards/placeholder.png"), "ERROR", RewardItemTypeEnumPatch.JAXCARD);
         cards.clear();
-        cards.add(new JAX());
+        JAX jax = new JAX();
+        for (AbstractRelic r : AbstractDungeon.player.relics) {
+            r.onPreviewObtainCard(jax);
+        }
+        cards.add(jax);
         this.text = TEXT[0] + cards.get(0).name + TEXT[1];
     }
 

--- a/src/main/java/downfall/util/RareCardReward.java
+++ b/src/main/java/downfall/util/RareCardReward.java
@@ -11,6 +11,7 @@ import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
 import com.megacrit.cardcrawl.helpers.*;
 import com.megacrit.cardcrawl.helpers.controller.CInputActionSet;
 import com.megacrit.cardcrawl.helpers.input.InputHelper;
+import com.megacrit.cardcrawl.relics.AbstractRelic;
 import com.megacrit.cardcrawl.rewards.RewardItem;
 import com.megacrit.cardcrawl.vfx.AbstractGameEffect;
 import com.megacrit.cardcrawl.vfx.RewardGlowEffect;
@@ -51,26 +52,14 @@ public class RareCardReward extends RewardItem {
             while (cardListDuplicate(cardToAdd)) {
                 cardToAdd = AbstractDungeon.getCard(AbstractCard.CardRarity.RARE).makeCopy();
             }
+            for (AbstractRelic r : AbstractDungeon.player.relics) {
+                r.onPreviewObtainCard(cardToAdd);
+            }
             this.cards.add(cardToAdd);
         }
 
         this.text = TEXT[0];
-        Iterator var2 = this.cards.iterator();
 
-        while (true) {
-            while (var2.hasNext()) {
-                AbstractCard c = (AbstractCard) var2.next();
-                if (c.type == AbstractCard.CardType.ATTACK && AbstractDungeon.player.hasRelic("Molten Egg 2")) {
-                    c.upgrade();
-                } else if (c.type == AbstractCard.CardType.SKILL && AbstractDungeon.player.hasRelic("Toxic Egg 2")) {
-                    c.upgrade();
-                } else if (c.type == AbstractCard.CardType.POWER && AbstractDungeon.player.hasRelic("Frozen Egg 2")) {
-                    c.upgrade();
-                }
-            }
-
-            return;
-        }
     }
 
     public static AbstractCard getRandomSeal() {

--- a/src/main/java/guardian/events/AccursedBlacksmithGuardian.java
+++ b/src/main/java/guardian/events/AccursedBlacksmithGuardian.java
@@ -93,6 +93,7 @@ public class AccursedBlacksmithGuardian extends AbstractImageEvent {
             AbstractDungeon.effectsQueue.add(new ShowCardBrieflyEffect(c.makeStatEquivalentCopy()));
             AbstractDungeon.topLevelEffects.add(new UpgradeShineEffect((float) Settings.WIDTH / 2.0F, (float) Settings.HEIGHT / 2.0F));
             AbstractDungeon.gridSelectScreen.selectedCards.clear();
+            logMetricCardUpgrade(ID, "Forge", c);
             this.pickCard = false;
         } else if (this.pickCardForSocket && !AbstractDungeon.isScreenUp && !AbstractDungeon.gridSelectScreen.selectedCards.isEmpty()) {
             AbstractCard c = AbstractDungeon.gridSelectScreen.selectedCards.get(0);
@@ -102,6 +103,7 @@ public class AccursedBlacksmithGuardian extends AbstractImageEvent {
             AbstractDungeon.effectsQueue.add(new ShowCardBrieflyEffect(c.makeStatEquivalentCopy()));
             AbstractDungeon.topLevelEffects.add(new UpgradeShineEffect((float) Settings.WIDTH / 2.0F, (float) Settings.HEIGHT / 2.0F));
             AbstractDungeon.gridSelectScreen.selectedCards.clear();
+            logMetricCardUpgrade(ID, "Tinker", c);
             this.pickCardForSocket = false;
         }
 
@@ -132,12 +134,14 @@ public class AccursedBlacksmithGuardian extends AbstractImageEvent {
                         AbstractCard curse = new Pain();
                         AbstractDungeon.effectList.add(new ShowCardAndObtainEffect(curse, (float) (Settings.WIDTH / 2), (float) (Settings.HEIGHT / 2)));
                         AbstractDungeon.getCurrRoom().spawnRelicAndObtain((float) (Settings.WIDTH / 2), (float) (Settings.HEIGHT / 2), new WarpedTongs());
+                        logMetricObtainCardAndRelic(ID, "Rummage", curse, new WarpedTongs());
                         this.imageEventText.updateDialogOption(0, OPTIONS[2]);
                         break;
                     case 3:
                         this.screenNum = 2;
                         this.imageEventText.updateBodyText(LEAVE_RESULT);
                         this.imageEventText.updateDialogOption(0, OPTIONS[2]);
+                        logMetricIgnored(ID);
                 }
 
                 this.imageEventText.clearRemainingOptions();

--- a/src/main/java/guardian/events/BackToBasicsGuardian.java
+++ b/src/main/java/guardian/events/BackToBasicsGuardian.java
@@ -106,6 +106,7 @@ public class BackToBasicsGuardian extends AbstractImageEvent {
             AbstractDungeon.effectList.add(new PurgeCardEffect(c));
             AbstractDungeon.player.masterDeck.removeCard(c);
             AbstractDungeon.gridSelectScreen.selectedCards.remove(c);
+            logMetricCardRemoval(ID, "Elegance", c);
         }
 
     }
@@ -114,14 +115,16 @@ public class BackToBasicsGuardian extends AbstractImageEvent {
         switch (this.screen) {
             case INTRO:
                 if (buttonPressed == 0) {
-
+                    ArrayList<String> cards = new ArrayList<>();
                     for (AbstractCard c : cardsToRemove){
                         CardModifierManager.addModifier(c, new BraceMod());
+                        cards.add(c.cardID);
                    }
 
                     this.imageEventText.updateBodyText(DESCRIPTIONSGUARDIAN[0]);
                     this.imageEventText.updateDialogOption(0, OPTIONS[3]);
                     this.imageEventText.clearRemainingOptions();
+                    logMetricUpgradeCards(ID, "Endurance", cards);
                 } else if (buttonPressed == 1) {
                     if (CardGroup.getGroupWithoutBottledCards(AbstractDungeon.player.masterDeck.getPurgeableCards()).size() > 0) {
                         this.imageEventText.updateBodyText(DIALOG_2);
@@ -154,6 +157,7 @@ public class BackToBasicsGuardian extends AbstractImageEvent {
                 AbstractDungeon.effectList.add(new ShowCardBrieflyEffect(c.makeStatEquivalentCopy(), MathUtils.random(0.1F, 0.9F) * (float) Settings.WIDTH, MathUtils.random(0.2F, 0.8F) * (float) Settings.HEIGHT));
             }
         }
+        logMetricUpgradeCards(ID, "Simplicity", cardsUpgraded);
     }
 
     private enum CUR_SCREEN {

--- a/src/main/java/guardian/events/CrystalForge.java
+++ b/src/main/java/guardian/events/CrystalForge.java
@@ -53,6 +53,11 @@ public class CrystalForge extends AbstractImageEvent {
     private boolean pickCardForTransmute = false;
     private AbstractGuardianCard cardChosen = null;
     private AbstractGuardianCard gemChosen = null;
+    private ArrayList<String> cardsRemoved = new ArrayList<>();
+    private ArrayList<String> cardsTransformed = new ArrayList<>();
+    private ArrayList<String> cardsAdded = new ArrayList<>();
+    private ArrayList<String> cardsUpgraded = new ArrayList<>();
+
 
     public CrystalForge() {
         super(NAME, INTRO, GuardianMod.getResourcePath("/events/grimForge.jpg"));
@@ -106,6 +111,7 @@ public class CrystalForge extends AbstractImageEvent {
             AbstractDungeon.effectsQueue.add(new ShowCardBrieflyEffect(c.makeStatEquivalentCopy()));
             AbstractDungeon.gridSelectScreen.selectedCards.clear();
             this.pickCardForGemRemoval = false;
+            cardsUpgraded.add(c.cardID);
             updateEnhance();
         } else if (this.pickCardForSalvageGems && !AbstractDungeon.isScreenUp && !AbstractDungeon.gridSelectScreen.selectedCards.isEmpty()) {
             AbstractCard c = AbstractDungeon.gridSelectScreen.selectedCards.get(0);
@@ -156,23 +162,28 @@ public class CrystalForge extends AbstractImageEvent {
             for (int i = 0; i < rewardGemCards.size(); i++) {
                 AbstractCard c2 = rewardGemCards.get(i);
                 AbstractDungeon.effectList.add(new ShowCardAndObtainEffect(c2, (float) (Settings.WIDTH * (0.2 * (i + 1))), (float) (Settings.HEIGHT / 2)));
-
+                cardsAdded.add(c2.cardID);
             }
 
 
             AbstractDungeon.topLevelEffects.add(new PurgeCardEffect(c, (float) (Settings.WIDTH * 0.2), (float) (Settings.HEIGHT / 2)));
             AbstractDungeon.player.masterDeck.removeCard(c);
+            cardsRemoved.add(c.cardID);
 
             AbstractDungeon.gridSelectScreen.selectedCards.clear();
             this.pickCardForSalvageGems = false;
             updateEnhance();
         } else if (this.pickCardForTransmute && !AbstractDungeon.isScreenUp && !AbstractDungeon.gridSelectScreen.selectedCards.isEmpty()) {
-            ArrayList<AbstractCard> gems = GuardianMod.getRewardGemCards(false, 1);
+            AbstractCard gem = GuardianMod.getRewardGemCards(false, 1).get(0);
 
-            AbstractDungeon.effectList.add(new ShowCardAndObtainEffect(gems.get(0), (float) (Settings.WIDTH * .3), (float) (Settings.HEIGHT / 2)));
+            AbstractDungeon.effectList.add(new ShowCardAndObtainEffect(gem, (float) (Settings.WIDTH * .3), (float) (Settings.HEIGHT / 2)));
 
-            AbstractDungeon.topLevelEffects.add(new PurgeCardEffect(AbstractDungeon.gridSelectScreen.selectedCards.get(0), (float) (Settings.WIDTH * .7), (float) (Settings.HEIGHT / 2)));
-            AbstractDungeon.player.masterDeck.removeCard(AbstractDungeon.gridSelectScreen.selectedCards.get(0));
+            AbstractCard removedCard = AbstractDungeon.gridSelectScreen.selectedCards.get(0);
+            AbstractDungeon.topLevelEffects.add(new PurgeCardEffect(removedCard, (float) (Settings.WIDTH * .7), (float) (Settings.HEIGHT / 2)));
+            AbstractDungeon.player.masterDeck.removeCard(removedCard);
+
+            cardsRemoved.add(removedCard.cardID);
+            cardsTransformed.add(gem.cardID);
 
             AbstractDungeon.gridSelectScreen.selectedCards.clear();
             this.pickCardForTransmute = false;
@@ -196,6 +207,9 @@ public class CrystalForge extends AbstractImageEvent {
 
             AbstractDungeon.gridSelectScreen.selectedCards.clear();
             GuardianMod.gridScreenForSockets = false;
+            cardsUpgraded.add(cardChosen.cardID);
+            cardsRemoved.add(gemChosen.cardID);
+
             updateEnhance();
         }
 
@@ -256,6 +270,8 @@ public class CrystalForge extends AbstractImageEvent {
                         this.imageEventText.clearAllDialogs();
                         this.imageEventText.updateBodyText(LEAVE);
                         this.imageEventText.setDialogOption(OPTIONS[5]);
+                        logMetric(ID, "Forged", cardsAdded, cardsRemoved, cardsTransformed, cardsUpgraded, null, null, null,
+                                0, 0, 0, 0, 0, 0);
 
                         break;
                 }

--- a/src/main/java/guardian/events/GemMine.java
+++ b/src/main/java/guardian/events/GemMine.java
@@ -53,6 +53,9 @@ public class GemMine extends AbstractImageEvent {
     private int screenNum = 0;
     private boolean tookGems = false;
     private int damage;
+    private int damageTaken = 0;
+    private ArrayList<String> cardsAdded = new ArrayList<>();
+    private ArrayList<String> relicsAdded = new ArrayList<>();
 
     public GemMine() {
         super(NAME, DIALOG_START, GuardianMod.getResourcePath("/events/gemMine.jpg"));
@@ -95,6 +98,7 @@ public class GemMine extends AbstractImageEvent {
                             this.imageEventText.updateBodyText(DIALOG_MINEPICK);
                             ArrayList<AbstractCard> gems = GuardianMod.getRewardGemCards(false, 1);
                             AbstractCard card = gems.get(0);
+                            cardsAdded.add(card.cardID);
 
                             AbstractDungeon.effectList.add(new ShowCardAndObtainEffect(card, (float) (Settings.WIDTH / 2), (float) (Settings.HEIGHT / 2)));
                             CardCrawlGame.sound.play("MONSTER_BOOK_STAB_0");
@@ -123,10 +127,12 @@ public class GemMine extends AbstractImageEvent {
 
                         ArrayList<AbstractCard> gems = GuardianMod.getRewardGemCards(false, 1);
                         AbstractCard card = gems.get(0);
+                        cardsAdded.add(card.cardID);
 
                         AbstractDungeon.effectList.add(new ShowCardAndObtainEffect(card, (float) (Settings.WIDTH / 2), (float) (Settings.HEIGHT / 2)));
                         CardCrawlGame.sound.play("MONSTER_BOOK_STAB_0");
                         AbstractDungeon.player.damage(new DamageInfo(null, this.damage));
+                        this.damageTaken += damage;
                         this.tookGems = true;
                         return;
                     default:
@@ -140,6 +146,12 @@ public class GemMine extends AbstractImageEvent {
                         this.screenNum = 1;
                         this.imageEventText.updateDialogOption(0, OPTIONS[2]);
                         this.imageEventText.clearRemainingOptions();
+                        if(cardsAdded.size() > 0 || relicsAdded.size() > 0 || damageTaken > 0) {
+                            logMetric(ID, "Entered Mine", cardsAdded, null, null, null, relicsAdded, null, null,
+                                    0, 0, damageTaken, 0, 0, 0);
+                        } else {
+                            logMetricIgnored(ID);
+                        }
                         break;
                 }
             case 1:
@@ -157,6 +169,7 @@ public class GemMine extends AbstractImageEvent {
             if (!AbstractDungeon.player.hasRelic(PickAxe.ID)) {
                 AbstractDungeon.getCurrRoom().spawnRelicAndObtain((float) (Settings.WIDTH / 2), (float) (Settings.HEIGHT / 2), new guardian.relics.PickAxe());
                 AbstractDungeon.commonRelicPool.remove(PickAxe.ID);
+                relicsAdded.add(PickAxe.ID);
             }
             enterImageFromCombat();
         }

--- a/src/main/java/guardian/events/PurificationShrineGuardian.java
+++ b/src/main/java/guardian/events/PurificationShrineGuardian.java
@@ -52,7 +52,7 @@ public class PurificationShrineGuardian extends AbstractImageEvent {
         super.update();
         if (!AbstractDungeon.isScreenUp && !AbstractDungeon.gridSelectScreen.selectedCards.isEmpty()) {
             CardCrawlGame.sound.play("CARD_EXHAUST");
-            logMetricCardRemoval("Purifier", "Purged", AbstractDungeon.gridSelectScreen.selectedCards.get(0));
+            logMetricCardRemoval(ID, "Purged", AbstractDungeon.gridSelectScreen.selectedCards.get(0));
             AbstractDungeon.topLevelEffects.add(new PurgeCardEffect(AbstractDungeon.gridSelectScreen.selectedCards.get(0), (float) (Settings.WIDTH / 2), (float) (Settings.HEIGHT / 2)));
             AbstractDungeon.player.masterDeck.removeCard(AbstractDungeon.gridSelectScreen.selectedCards.get(0));
             AbstractDungeon.gridSelectScreen.selectedCards.clear();
@@ -68,16 +68,14 @@ public class PurificationShrineGuardian extends AbstractImageEvent {
                         this.screen = PurificationShrineGuardian.CUR_SCREEN.COMPLETE;
                         this.imageEventText.updateBodyText(CardCrawlGame.languagePack.getEventString("Guardian:Purifier").DESCRIPTIONS[0]);
                         ArrayList<AbstractCard> gems = GuardianMod.getRewardGemCards(false, 2);
-                        ArrayList<AbstractCard> rewards = new ArrayList<>();
-                        int rando;
-                        for (int i = 0; i < 2; ++i) {
-                            rando = AbstractDungeon.cardRng.random(gems.size() - 1);
-                            rewards.add(gems.get(rando));
-                            gems.remove(rando);
+                        ArrayList<String> gemIDs = new ArrayList<>();
+                        for (AbstractCard gem : gems) {
+                            gemIDs.add(gem.cardID);
                         }
+                        logMetricObtainCards(ID, "Smashed", gemIDs);
 
-                        AbstractDungeon.effectList.add(new ShowCardAndObtainEffect(rewards.get(0), (float) (Settings.WIDTH * 0.35), (float) (Settings.HEIGHT / 2)));
-                        AbstractDungeon.effectList.add(new ShowCardAndObtainEffect(rewards.get(1), (float) (Settings.WIDTH * 0.7), (float) (Settings.HEIGHT / 2)));
+                        AbstractDungeon.effectList.add(new ShowCardAndObtainEffect(gems.get(0), (float) (Settings.WIDTH * 0.35), (float) (Settings.HEIGHT / 2)));
+                        AbstractDungeon.effectList.add(new ShowCardAndObtainEffect(gems.get(1), (float) (Settings.WIDTH * 0.7), (float) (Settings.HEIGHT / 2)));
 
                         this.imageEventText.updateDialogOption(0, OPTIONS[1]);
                         this.imageEventText.clearRemainingOptions();
@@ -91,7 +89,7 @@ public class PurificationShrineGuardian extends AbstractImageEvent {
                         return;
                     case 2:
                         this.screen = PurificationShrineGuardian.CUR_SCREEN.COMPLETE;
-                        logMetricIgnored("Purifier");
+                        logMetricIgnored(ID);
                         this.imageEventText.updateBodyText(IGNORE);
                         this.imageEventText.updateDialogOption(0, OPTIONS[1]);
                         this.imageEventText.clearRemainingOptions();

--- a/src/main/java/guardian/events/StasisEgg.java
+++ b/src/main/java/guardian/events/StasisEgg.java
@@ -19,6 +19,8 @@ import guardian.GuardianMod;
 import downfall.cards.curses.Aged;
 import guardian.ui.RelicPreviewButton;
 
+import java.util.Collections;
+
 public class StasisEgg extends AbstractImageEvent {
     public static final String ID = "Guardian:StasisEgg";
     public static final String NAME;
@@ -70,12 +72,14 @@ public class StasisEgg extends AbstractImageEvent {
                 switch (buttonPressed) {
                     case 0:
                         this.imageEventText.updateBodyText(DIALOG_USE);
-                        AbstractDungeon.getCurrRoom().spawnRelicAndObtain((float) (Settings.WIDTH / 2), (float) (Settings.HEIGHT / 2), new guardian.relics.StasisEgg());
+                        guardian.relics.StasisEgg relic = new guardian.relics.StasisEgg();
+                        AbstractDungeon.getCurrRoom().spawnRelicAndObtain((float) (Settings.WIDTH / 2), (float) (Settings.HEIGHT / 2), relic);
                         AbstractCard card = new Aged();
                         AbstractDungeon.effectList.add(new ShowCardAndObtainEffect(card, (float) (Settings.WIDTH / 2), (float) (Settings.HEIGHT / 2)));
                         this.screenNum = 1;
                         this.imageEventText.updateDialogOption(0, OPTIONS[3]);
                         this.imageEventText.clearRemainingOptions();
+                        logMetricObtainCardAndRelic(ID, "Took Egg", card, relic);
 
                         return;
                     case 1:
@@ -88,6 +92,9 @@ public class StasisEgg extends AbstractImageEvent {
                         this.screenNum = 1;
                         this.imageEventText.updateDialogOption(0, OPTIONS[3]);
                         this.imageEventText.clearRemainingOptions();
+                        logMetric(ID, "Smashed Egg", Collections.singletonList(card2.cardID), null, null, null,
+                                null, null, null,
+                                0, 0, 0, maxHP, 0, 0);
 
                         return;
                     case 2:
@@ -96,6 +103,7 @@ public class StasisEgg extends AbstractImageEvent {
                         this.screenNum = 1;
                         this.imageEventText.updateDialogOption(0, OPTIONS[3]);
                         this.imageEventText.clearRemainingOptions();
+                        logMetricIgnored(ID);
                         return;
                 }
             case 1:

--- a/src/main/java/guardian/events/TransmogrifierGuardian.java
+++ b/src/main/java/guardian/events/TransmogrifierGuardian.java
@@ -58,7 +58,7 @@ public class TransmogrifierGuardian extends AbstractImageEvent {
             AbstractDungeon.player.masterDeck.removeCard(c);
             AbstractDungeon.transformCard(c);
             AbstractCard transCard = AbstractDungeon.getTransformedCard();
-            logMetricTransformCard("Transmorgrifier", "Transformed", c, transCard);
+            logMetricTransformCard(ID, "Transformed", c, transCard);
             AbstractDungeon.effectsQueue.add(new ShowCardAndObtainEffect(transCard, (float) Settings.WIDTH / 2.0F, (float) Settings.HEIGHT / 2.0F));
             AbstractDungeon.gridSelectScreen.selectedCards.clear();
         }
@@ -73,16 +73,15 @@ public class TransmogrifierGuardian extends AbstractImageEvent {
                         this.screen = TransmogrifierGuardian.CUR_SCREEN.COMPLETE;
                         this.imageEventText.updateBodyText(CardCrawlGame.languagePack.getEventString("Guardian:Purifier").DESCRIPTIONS[0]);
                         ArrayList<AbstractCard> gems = GuardianMod.getRewardGemCards(false, 2);
-                        ArrayList<AbstractCard> rewards = new ArrayList<>();
-                        int rando;
-                        for (int i = 0; i < 2; ++i) {
-                            rando = AbstractDungeon.cardRng.random(gems.size() - 1);
-                            rewards.add(gems.get(rando));
-                            gems.remove(rando);
+                        ArrayList<String> gemIDs = new ArrayList<>();
+                        for (AbstractCard gem : gems) {
+                            gemIDs.add(gem.cardID);
                         }
+                        logMetricObtainCards(ID, "Smashed", gemIDs);
 
-                        AbstractDungeon.effectList.add(new ShowCardAndObtainEffect(rewards.get(0), (float) (Settings.WIDTH * 0.35), (float) (Settings.HEIGHT / 2)));
-                        AbstractDungeon.effectList.add(new ShowCardAndObtainEffect(rewards.get(1), (float) (Settings.WIDTH * 0.7), (float) (Settings.HEIGHT / 2)));
+
+                        AbstractDungeon.effectList.add(new ShowCardAndObtainEffect(gems.get(0), (float) (Settings.WIDTH * 0.35), (float) (Settings.HEIGHT / 2)));
+                        AbstractDungeon.effectList.add(new ShowCardAndObtainEffect(gems.get(1), (float) (Settings.WIDTH * 0.7), (float) (Settings.HEIGHT / 2)));
 
                         this.imageEventText.updateDialogOption(0, OPTIONS[1]);
                         this.imageEventText.clearRemainingOptions();
@@ -96,7 +95,7 @@ public class TransmogrifierGuardian extends AbstractImageEvent {
                         return;
                     case 2:
                         this.screen = TransmogrifierGuardian.CUR_SCREEN.COMPLETE;
-                        logMetricIgnored("Transmorgrifier");
+                        logMetricIgnored(ID);
                         this.imageEventText.updateBodyText(IGNORE);
                         this.imageEventText.updateDialogOption(0, OPTIONS[1]);
                         this.imageEventText.clearRemainingOptions();

--- a/src/main/java/guardian/events/UpgradeShrineGuardian.java
+++ b/src/main/java/guardian/events/UpgradeShrineGuardian.java
@@ -59,7 +59,7 @@ public class UpgradeShrineGuardian extends AbstractImageEvent {
         if (!AbstractDungeon.isScreenUp && !AbstractDungeon.gridSelectScreen.selectedCards.isEmpty()) {
             AbstractCard c = AbstractDungeon.gridSelectScreen.selectedCards.get(0);
             c.upgrade();
-            logMetricCardUpgrade("Upgrade Shrine", "Upgraded", c);
+            logMetricCardUpgrade(ID, "Upgraded", c);
             AbstractDungeon.player.bottledCardUpgradeCheck(c);
             AbstractDungeon.effectsQueue.add(new ShowCardBrieflyEffect(c.makeStatEquivalentCopy()));
             AbstractDungeon.topLevelEffects.add(new UpgradeShineEffect((float) Settings.WIDTH / 2.0F, (float) Settings.HEIGHT / 2.0F));
@@ -76,16 +76,15 @@ public class UpgradeShrineGuardian extends AbstractImageEvent {
                         this.screen = UpgradeShrineGuardian.CUR_SCREEN.COMPLETE;
                         this.imageEventText.updateBodyText(CardCrawlGame.languagePack.getEventString("Guardian:Purifier").DESCRIPTIONS[0]);
                         ArrayList<AbstractCard> gems = GuardianMod.getRewardGemCards(false, 2);
-                        ArrayList<AbstractCard> rewards = new ArrayList<>();
-                        int rando;
-                        for (int i = 0; i < 2; ++i) {
-                            rando = AbstractDungeon.cardRng.random(gems.size() - 1);
-                            rewards.add(gems.get(rando));
-                            gems.remove(rando);
+                        ArrayList<String> gemIDs = new ArrayList<>();
+                        for (AbstractCard gem : gems) {
+                            gemIDs.add(gem.cardID);
                         }
+                        logMetricObtainCards(ID, "Smashed", gemIDs);
 
-                        AbstractDungeon.effectList.add(new ShowCardAndObtainEffect(rewards.get(0), (float) (Settings.WIDTH * 0.35), (float) (Settings.HEIGHT / 2)));
-                        AbstractDungeon.effectList.add(new ShowCardAndObtainEffect(rewards.get(1), (float) (Settings.WIDTH * 0.7), (float) (Settings.HEIGHT / 2)));
+
+                        AbstractDungeon.effectList.add(new ShowCardAndObtainEffect(gems.get(0), (float) (Settings.WIDTH * 0.35), (float) (Settings.HEIGHT / 2)));
+                        AbstractDungeon.effectList.add(new ShowCardAndObtainEffect(gems.get(1), (float) (Settings.WIDTH * 0.7), (float) (Settings.HEIGHT / 2)));
 
                         this.imageEventText.updateDialogOption(0, OPTIONS[1]);
                         this.imageEventText.clearRemainingOptions();
@@ -101,7 +100,7 @@ public class UpgradeShrineGuardian extends AbstractImageEvent {
                     case 2:
                         this.screen = UpgradeShrineGuardian.CUR_SCREEN.COMPLETE;
                         AbstractDungeon.getCurrRoom().phase = RoomPhase.COMPLETE;
-                        logMetricIgnored("Upgrade Shrine");
+                        logMetricIgnored(ID);
                         this.imageEventText.updateBodyText(IGNORE);
                         this.imageEventText.updateDialogOption(0, OPTIONS[1]);
                         this.imageEventText.clearRemainingOptions();


### PR DESCRIPTION
Background:

Downfall events do not show any details in the Run History screen, due to not logging any metrics. A crash was found when loading a saved game that was saved after a particular event, and it was discovered that the crash was directly caused by the missing metrics for that event. Additionally, the event's internal ID in the metrics is used to recreate the event while loading the saved game.

I will examine each Downfall event and make changes such that metrics are logged using the event's own internal ID, and that the outcomes of each event are correctly logged so they can be reviewed in the Run History. A small patch also allows the Run History to properly display the name (or internal ID, if something goes wrong) of each Downfall event, since the base game has hardcoded the Run History names for vanilla events.

This branch is a work in progress. I'm posting it here so that if the unexpected happens, somebody else will be able to continue the work.