### PR TITLE
Event audit continued

### DIFF
--- a/src/main/java/automaton/events/AccursedBlacksmithAutomaton.java
+++ b/src/main/java/automaton/events/AccursedBlacksmithAutomaton.java
@@ -53,7 +53,6 @@ public class AccursedBlacksmithAutomaton extends AbstractImageEvent {
 
     private int screenNum = 0;
     private boolean pickCard = false;
-    private boolean pickCardForSocket = false;
 
     private ArrayList<AbstractCard> validCards;
 
@@ -93,24 +92,42 @@ public class AccursedBlacksmithAutomaton extends AbstractImageEvent {
 
     }
 
+    public void update()
+    {
+        super.update();
+
+        if ((this.pickCard) &&
+                (!AbstractDungeon.isScreenUp) && (!AbstractDungeon.gridSelectScreen.selectedCards.isEmpty())) {
+            AbstractCard c = AbstractDungeon.gridSelectScreen.selectedCards.get(0);
+            c.upgrade();
+            logMetricCardUpgrade(ID, "Forge", c);
+            AbstractDungeon.player.bottledCardUpgradeCheck(AbstractDungeon.gridSelectScreen.selectedCards.get(0));
+            AbstractDungeon.effectsQueue.add(new com.megacrit.cardcrawl.vfx.cardManip.ShowCardBrieflyEffect(c.makeStatEquivalentCopy()));
+            AbstractDungeon.topLevelEffects.add(new com.megacrit.cardcrawl.vfx.UpgradeShineEffect(Settings.WIDTH / 2.0F, Settings.HEIGHT / 2.0F));
+            AbstractDungeon.gridSelectScreen.selectedCards.clear();
+            this.pickCard = false;
+        }
+    }
 
     protected void buttonEffect(int buttonPressed) {
         switch (this.screenNum) {
             case 0:
                 switch (buttonPressed) {
                     case 0:
-                        this.pickCardForSocket = true;
                         this.imageEventText.updateBodyText(DESCRIPTIONSAUTOMATON[0]);
                         this.screenNum = 2;
                         this.imageEventText.updateDialogOption(0, OPTIONS[2]);
                         Collections.shuffle(validCards);
+                        ArrayList<String> upgradedCards = new ArrayList<>();
                         for (int i = 0; i < 3; i++) {
                             if (validCards.size() - 1 >= i){
+                                upgradedCards.add(validCards.get(i).cardID);
                                 validCards.get(i).upgrade();
                                 AbstractDungeon.effectList.add(new ShowCardBrieflyEffect(validCards.get(i).makeStatEquivalentCopy(), MathUtils.random(0.1F, 0.9F) * (float) Settings.WIDTH, MathUtils.random(0.2F, 0.8F) * (float) Settings.HEIGHT));
 
                             }
                         }
+                        logMetricUpgradeCards(ID, "Tinker", upgradedCards);
 
                         break;
                     case 1:
@@ -126,12 +143,14 @@ public class AccursedBlacksmithAutomaton extends AbstractImageEvent {
                         AbstractCard curse = new Pain();
                         AbstractDungeon.effectList.add(new ShowCardAndObtainEffect(curse, (float) (Settings.WIDTH / 2), (float) (Settings.HEIGHT / 2)));
                         AbstractDungeon.getCurrRoom().spawnRelicAndObtain((float) (Settings.WIDTH / 2), (float) (Settings.HEIGHT / 2), new WarpedTongs());
+                        logMetricObtainCardAndRelic(ID, "Rummage", curse, new WarpedTongs());
                         this.imageEventText.updateDialogOption(0, OPTIONS[2]);
                         break;
                     case 3:
                         this.screenNum = 2;
                         this.imageEventText.updateBodyText(LEAVE_RESULT);
                         this.imageEventText.updateDialogOption(0, OPTIONS[2]);
+                        logMetricIgnored(ID);
                 }
 
                 this.imageEventText.clearRemainingOptions();

--- a/src/main/java/automaton/events/AncientFactory.java
+++ b/src/main/java/automaton/events/AncientFactory.java
@@ -57,6 +57,7 @@ public class AncientFactory extends AbstractImageEvent {
             case INTRO:
                 switch (buttonPressed) {
                     case 0:
+                        logMetric(ID, "Fought Donu");
                         this.screen = CurScreen.FIGHT;
                         //SlimeboundMod.logger.info("fight");
                         m = new ProtoDonu();
@@ -73,7 +74,7 @@ public class AncientFactory extends AbstractImageEvent {
 
                         return;
                     case 1:
-
+                        logMetric(ID, "Fought Deca");
                         this.screen = CurScreen.FIGHT;
                         //SlimeboundMod.logger.info("fight");
                         m = new ProtoDeca();
@@ -89,6 +90,7 @@ public class AncientFactory extends AbstractImageEvent {
                         this.enterCombatFromImage();
                         return;
                     case 2:
+                        logMetric(ID, "Fought Donu and Deca");
                         this.screen = CurScreen.FIGHT;
                         //SlimeboundMod.logger.info("fight");
                         m = new ProtoDonu();
@@ -113,6 +115,7 @@ public class AncientFactory extends AbstractImageEvent {
                         this.imageEventText.updateBodyText(DESCRIPTIONS[1]);
                         this.imageEventText.clearAllDialogs();
                         this.imageEventText.setDialogOption(OPTIONS[3]);
+                        logMetricIgnored(ID);
                         return;
                     default:
                         return;

--- a/src/main/java/automaton/events/BackToBasicsAutomaton.java
+++ b/src/main/java/automaton/events/BackToBasicsAutomaton.java
@@ -111,6 +111,7 @@ public class BackToBasicsAutomaton extends AbstractImageEvent {
             AbstractDungeon.effectList.add(new PurgeCardEffect(c));
             AbstractDungeon.player.masterDeck.removeCard(c);
             AbstractDungeon.gridSelectScreen.selectedCards.remove(c);
+            logMetricCardRemoval(ID, "Elegance", c);
         }
 
     }
@@ -119,10 +120,12 @@ public class BackToBasicsAutomaton extends AbstractImageEvent {
         switch (this.screen) {
             case INTRO:
                 if (buttonPressed == 0) {
-
+                    ArrayList<String> cardsEncoded = new ArrayList<>();
                     for (AbstractCard c : cardsToRemove){
                         CardModifierManager.addModifier(c, new EncodeMod());
-                   }
+                        cardsEncoded.add(c.cardID);
+                    }
+                    logMetricUpgradeCards(ID, "Unification", cardsEncoded);
 
                     this.imageEventText.updateBodyText(DESCRIPTIONSGUARDIAN[0]);
                     this.imageEventText.updateDialogOption(0, OPTIONS[3]);
@@ -159,6 +162,7 @@ public class BackToBasicsAutomaton extends AbstractImageEvent {
                 AbstractDungeon.effectList.add(new ShowCardBrieflyEffect(c.makeStatEquivalentCopy(), MathUtils.random(0.1F, 0.9F) * (float) Settings.WIDTH, MathUtils.random(0.2F, 0.8F) * (float) Settings.HEIGHT));
             }
         }
+        logMetricUpgradeCards(ID, "Simplicity", cardsUpgraded);
     }
     private enum CUR_SCREEN {
         INTRO,

--- a/src/main/java/automaton/events/CrystalForgeAutomaton.java
+++ b/src/main/java/automaton/events/CrystalForgeAutomaton.java
@@ -93,20 +93,27 @@ public class CrystalForgeAutomaton extends AbstractImageEvent {
         super.update();
         if (pickCardForTransmute && !AbstractDungeon.isScreenUp && !AbstractDungeon.gridSelectScreen.selectedCards.isEmpty()) {
 
-            AbstractDungeon.effectList.add(new ShowCardAndObtainEffect(SpaghettiCode.getRandomEncode().makeStatEquivalentCopy(), (float) (Settings.WIDTH * .3), (float) (Settings.HEIGHT / 2)));
+            AbstractCard cardGained = SpaghettiCode.getRandomEncode().makeStatEquivalentCopy();
+            AbstractDungeon.effectList.add(new ShowCardAndObtainEffect(cardGained, (float) (Settings.WIDTH * .3), (float) (Settings.HEIGHT / 2)));
 
-            AbstractDungeon.topLevelEffects.add(new PurgeCardEffect(AbstractDungeon.gridSelectScreen.selectedCards.get(0), (float) (Settings.WIDTH * .7), (float) (Settings.HEIGHT / 2)));
-            AbstractDungeon.player.masterDeck.removeCard(AbstractDungeon.gridSelectScreen.selectedCards.get(0));
+            AbstractCard cardLost = AbstractDungeon.gridSelectScreen.selectedCards.get(0);
+            AbstractDungeon.topLevelEffects.add(new PurgeCardEffect(cardLost, (float) (Settings.WIDTH * .7), (float) (Settings.HEIGHT / 2)));
+            AbstractDungeon.player.masterDeck.removeCard(cardLost);
 
             AbstractDungeon.gridSelectScreen.selectedCards.clear();
+            logMetricObtainCardAndLoseCard(ID, "Transmute", cardGained, cardLost);
 
         } else if (pickCardForHP && !AbstractDungeon.isScreenUp && !AbstractDungeon.gridSelectScreen.selectedCards.isEmpty()) {
 
-            AbstractDungeon.topLevelEffects.add(new PurgeCardEffect(AbstractDungeon.gridSelectScreen.selectedCards.get(0), (float) (Settings.WIDTH * .7), (float) (Settings.HEIGHT / 2)));
-            AbstractDungeon.player.masterDeck.removeCard(AbstractDungeon.gridSelectScreen.selectedCards.get(0));
+            AbstractCard c = AbstractDungeon.gridSelectScreen.selectedCards.get(0);
+            AbstractDungeon.topLevelEffects.add(new PurgeCardEffect(c, (float) (Settings.WIDTH * .7), (float) (Settings.HEIGHT / 2)));
+            AbstractDungeon.player.masterDeck.removeCard(c);
 
             AbstractDungeon.gridSelectScreen.selectedCards.clear();
-            AbstractDungeon.player.increaseMaxHp(10, true);
+            int maxHpUp = 10;
+            AbstractDungeon.player.increaseMaxHp(maxHpUp, true);
+            logMetricCardRemovalHealMaxHPUp(ID, "Reforge", c, AbstractDungeon.player.maxHealth - AbstractDungeon.player.currentHealth, maxHpUp);
+
             AbstractDungeon.player.heal(AbstractDungeon.player.maxHealth);
 
         }
@@ -123,11 +130,13 @@ public class CrystalForgeAutomaton extends AbstractImageEvent {
                         this.screenNum = 2;
                         //this.pickCardForSalvageGems = true;
                         this.imageEventText.updateBodyText(COMBINE);
-                        AbstractDungeon.getCurrRoom().spawnRelicAndObtain((float) (Settings.WIDTH / 2), (float) (Settings.HEIGHT / 2), new BottledCode());
+                        BottledCode relic = new BottledCode();
+                        AbstractDungeon.getCurrRoom().spawnRelicAndObtain((float) (Settings.WIDTH / 2), (float) (Settings.HEIGHT / 2), relic);
 
                         AbstractDungeon.player.decreaseMaxHealth(10);
                         this.imageEventText.clearAllDialogs();
                         this.imageEventText.setDialogOption(OPTIONS[4]);
+                        logMetricObtainRelicAndLoseMaxHP(ID, "Craft", relic, 10);
                         break;
                     case 1:
                         this.screenNum = 2;
@@ -154,6 +163,7 @@ public class CrystalForgeAutomaton extends AbstractImageEvent {
                         this.imageEventText.clearAllDialogs();
                         this.imageEventText.updateBodyText(LEAVE);
                         this.imageEventText.setDialogOption(OPTIONS[4]);
+                        logMetricIgnored(ID);
 
                         break;
                 }

--- a/src/main/java/automaton/events/ShapeFactory.java
+++ b/src/main/java/automaton/events/ShapeFactory.java
@@ -92,6 +92,7 @@ public class ShapeFactory extends AbstractImageEvent {
                         this.imageEventText.updateBodyText(DESCRIPTIONS[1]);
                         this.imageEventText.clearAllDialogs();
                         this.imageEventText.setDialogOption(OPTIONS[3]);
+                        logMetricIgnored(ID);
                         return;
                     default:
                         return;
@@ -156,7 +157,6 @@ public class ShapeFactory extends AbstractImageEvent {
         this.screen = CurScreen.FIGHT;
         //SlimeboundMod.logger.info("fight");
         float spawnX = 0F;
-
         AbstractDungeon.getCurrRoom().rewards.clear();
         if (fightSpiker){
             AbstractDungeon.getCurrRoom().rewards.add(new SpikeReward());
@@ -167,6 +167,8 @@ public class ShapeFactory extends AbstractImageEvent {
         if (fightExploder){
             AbstractDungeon.getCurrRoom().rewards.add(new ExplodeReward());
         }
+        int numShapes = AbstractDungeon.getCurrRoom().rewards.size();
+        logMetric(ID, "Fought " + numShapes + " shapes");
 
         if (fightSpiker){
             AbstractDungeon.getCurrRoom().monsters = new MonsterGroup(new Spiker(spawnX, 0.0F));

--- a/src/main/java/champ/events/BackToBasicsChamp.java
+++ b/src/main/java/champ/events/BackToBasicsChamp.java
@@ -111,8 +111,8 @@ public class BackToBasicsChamp extends AbstractImageEvent {
             AbstractDungeon.effectList.add(new PurgeCardEffect(c));
             AbstractDungeon.player.masterDeck.removeCard(c);
             AbstractDungeon.gridSelectScreen.selectedCards.remove(c);
+            logMetricCardRemoval(ID, "Elegance", c);
         }
-
     }
 
     protected void buttonEffect(int buttonPressed) {
@@ -149,24 +149,20 @@ public class BackToBasicsChamp extends AbstractImageEvent {
 
 
     private void techStrikeAndDefends() {
-        Iterator var1 = AbstractDungeon.player.masterDeck.group.iterator();
+        ArrayList<String> cardsTeched = new ArrayList<>();
 
-        while (true) {
-            AbstractCard c;
-            do {
-                if (!var1.hasNext()) {
-                    return;
+        for(AbstractCard c: AbstractDungeon.player.masterDeck.group) {
+            if (c.hasTag(AbstractCard.CardTags.STARTER_STRIKE) || c.hasTag(AbstractCard.CardTags.STARTER_DEFEND)) {
+                if (!c.hasTag(ChampMod.TECHNIQUE)) {
+                    CardModifierManager.addModifier(c, new TechniqueMod());
+                    c.initializeDescription();
+                    cardsTeched.add(c.cardID);
                 }
-
-                c = (AbstractCard) var1.next();
-            } while (!c.hasTag(AbstractCard.CardTags.STARTER_STRIKE) && !c.hasTag(AbstractCard.CardTags.STARTER_DEFEND));
-
-            if (!c.hasTag(ChampMod.TECHNIQUE)) {
-                CardModifierManager.addModifier(c, new TechniqueMod());
-            c.initializeDescription();
             }
         }
+        logMetricUpgradeCards(ID, "Intuition", cardsTeched);
     }
+
     private void upgradeStrikeAndDefends() {
         for (AbstractCard c: AbstractDungeon.player.masterDeck.group){
             if (c.canUpgrade() && (c.hasTag(AbstractCard.CardTags.STARTER_DEFEND) || c.hasTag(AbstractCard.CardTags.STARTER_STRIKE)) ) {
@@ -176,6 +172,7 @@ public class BackToBasicsChamp extends AbstractImageEvent {
                 AbstractDungeon.effectList.add(new ShowCardBrieflyEffect(c.makeStatEquivalentCopy(), MathUtils.random(0.1F, 0.9F) * (float) Settings.WIDTH, MathUtils.random(0.2F, 0.8F) * (float) Settings.HEIGHT));
             }
         }
+        logMetricUpgradeCards(ID, "Simplicity", cardsUpgraded);
     }
 
     private enum CUR_SCREEN {

--- a/src/main/java/champ/events/Colosseum_Evil_Champ.java
+++ b/src/main/java/champ/events/Colosseum_Evil_Champ.java
@@ -51,6 +51,7 @@ public class Colosseum_Evil_Champ extends AbstractImageEvent {
             case INTRO:
                 switch (buttonPressed) {
                     case 0:
+                        logMetric(ID, "Fought Black Knight");
                         this.screen = CurScreen.FIGHT;
                         this.imageEventText.updateBodyText(DESCRIPTIONS[2] + DESCRIPTIONS[3]);
                         //SlimeboundMod.logger.info("fight");
@@ -65,6 +66,7 @@ public class Colosseum_Evil_Champ extends AbstractImageEvent {
 
                         return;
                     case 1:
+                        logMetric(ID, "Fought Captured Player");
                         this.screen = CurScreen.FIGHT;
                         this.imageEventText.updateBodyText(DESCRIPTIONS[2] + DESCRIPTIONS[4]);
                         //SlimeboundMod.logger.info("fight");
@@ -110,6 +112,7 @@ public class Colosseum_Evil_Champ extends AbstractImageEvent {
                         this.imageEventText.updateBodyText(DESCRIPTIONS[5]);
                         this.imageEventText.clearAllDialogs();
                         this.imageEventText.setDialogOption(OPTIONS[2]);
+                        logMetricIgnored(ID);
                         return;
                     default:
                         return;

--- a/src/main/java/champ/events/Gym.java
+++ b/src/main/java/champ/events/Gym.java
@@ -76,9 +76,8 @@ public class Gym extends AbstractImageEvent {
             this.imageEventText.updateDialogOption(0, OPTIONS[4]);
             this.pickCard = false;
             this.screen = CurScreen.RESULT;
-
+            logMetricCardUpgrade(ID, "Spar", c);
         }
-
     }
 
     protected void buttonEffect(int buttonPressed) {
@@ -91,6 +90,7 @@ public class Gym extends AbstractImageEvent {
                         this.imageEventText.setDialogOption(OPTIONS[4]);
                         AbstractDungeon.player.increaseMaxHp(maxHP, true);
                         this.screen = CurScreen.RESULT;
+                        logMetricMaxHPGain(ID, "Cardio", maxHP);
                         return;
                     case 1:
                        // this.imageEventText.updateBodyText(DESCRIPTIONS[2]);
@@ -103,9 +103,11 @@ public class Gym extends AbstractImageEvent {
                         this.imageEventText.updateBodyText(DESCRIPTIONS[3]);
                         this.imageEventText.clearAllDialogs();
                         this.imageEventText.setDialogOption(OPTIONS[4]);
-                        AbstractDungeon.getCurrRoom().spawnRelicAndObtain((float) Settings.WIDTH / 2.0F, (float) Settings.HEIGHT / 2.0F, new LiftRelic());
+                        LiftRelic relic = new LiftRelic();
+                        AbstractDungeon.getCurrRoom().spawnRelicAndObtain((float) Settings.WIDTH / 2.0F, (float) Settings.HEIGHT / 2.0F, relic);
 
                         this.screen = CurScreen.RESULT;
+                        logMetricObtainRelic(ID, "Lift", relic);
                         return;
                     default:
                         return;

--- a/src/main/java/champ/events/Library_Champ.java
+++ b/src/main/java/champ/events/Library_Champ.java
@@ -71,7 +71,7 @@ public class Library_Champ extends AbstractImageEvent {
         super.update();
         if (this.pickCard && !AbstractDungeon.isScreenUp && !AbstractDungeon.gridSelectScreen.selectedCards.isEmpty()) {
             AbstractCard c = ((AbstractCard)AbstractDungeon.gridSelectScreen.selectedCards.get(0)).makeCopy();
-            logMetricObtainCard("The Library", "Read", c);
+            logMetricObtainCard(ID, "Read", c);
             AbstractDungeon.effectList.add(new ShowCardAndObtainEffect(c, (float)Settings.WIDTH / 2.0F, (float)Settings.HEIGHT / 2.0F));
             AbstractDungeon.gridSelectScreen.selectedCards.clear();
         }
@@ -138,7 +138,7 @@ public class Library_Champ extends AbstractImageEvent {
                     case 1:
                         this.imageEventText.updateBodyText(SLEEP_RESULT);
                         AbstractDungeon.player.heal(this.healAmt, true);
-                        logMetricHeal("The Library", "Heal", this.healAmt);
+                        logMetricHeal(ID, "Heal", this.healAmt);
                         this.screenNum = 1;
                         this.imageEventText.updateDialogOption(0, OPTIONS[3]);
                         this.imageEventText.clearRemainingOptions();
@@ -147,6 +147,7 @@ public class Library_Champ extends AbstractImageEvent {
                         AbstractRelic r = this.getRandomFace();
                         AbstractDungeon.getCurrRoom().spawnRelicAndObtain((float) Settings.WIDTH / 2.0F, (float) Settings.HEIGHT / 2.0F, r);
                         downfallMod.removeAnyRelicFromPools(r.relicId);
+                        logMetricObtainRelic(ID, "Seek", r);
                         this.imageEventText.updateBodyText(DESCRIPTIONSALT[1]);
                         this.screenNum = 1;
                         this.imageEventText.updateDialogOption(0, OPTIONS[3]);

--- a/src/main/java/champ/events/MinorLeagueArena.java
+++ b/src/main/java/champ/events/MinorLeagueArena.java
@@ -47,6 +47,7 @@ public class MinorLeagueArena extends AbstractImageEvent {
             case INTRO:
                 switch (buttonPressed) {
                     case 0:
+                        logMetric(ID, "Fight");
                         this.screen = CurScreen.FIGHT;
                         //SlimeboundMod.logger.info("fight");
                         AbstractDungeon.getCurrRoom().monsters = MonsterHelper.getEncounter("Centurion and Healer");
@@ -54,11 +55,13 @@ public class MinorLeagueArena extends AbstractImageEvent {
                         AbstractDungeon.getCurrRoom().addRelicToRewards(new CloakClasp());
                         AbstractDungeon.getCurrRoom().addGoldToRewards(100);
                         AbstractDungeon.getCurrRoom().eliteTrigger = true;
+                        AbstractDungeon.lastCombatMetricKey = "Centurion and Healer";
                         this.imageEventText.clearAllDialogs();
                         this.enterCombatFromImage();
 
                         return;
                     case 1:
+                        logMetric(ID, "Fight");
 
                         this.screen = CurScreen.FIGHT;
                         //SlimeboundMod.logger.info("fight");
@@ -67,10 +70,12 @@ public class MinorLeagueArena extends AbstractImageEvent {
                         AbstractDungeon.getCurrRoom().addRelicToRewards(new ChampionsBelt());
                         AbstractDungeon.getCurrRoom().addGoldToRewards(100);
                         AbstractDungeon.getCurrRoom().eliteTrigger = true;
+                        AbstractDungeon.lastCombatMetricKey = "Gremlin Nob";
                         this.imageEventText.clearAllDialogs();
                         this.enterCombatFromImage();
                         return;
                     case 2:
+                        logMetric(ID, "Fight");
                         this.screen = CurScreen.FIGHT;
                         //SlimeboundMod.logger.info("fight");
                         AbstractDungeon.getCurrRoom().monsters = MonsterHelper.getEncounter("Colosseum Slavers");
@@ -78,6 +83,7 @@ public class MinorLeagueArena extends AbstractImageEvent {
                         AbstractDungeon.getCurrRoom().addRelicToRewards(new WristBlade());
                         AbstractDungeon.getCurrRoom().addGoldToRewards(100);
                         AbstractDungeon.getCurrRoom().eliteTrigger = true;
+                        AbstractDungeon.lastCombatMetricKey = "Colosseum Slavers";
                         this.imageEventText.clearAllDialogs();
                         this.enterCombatFromImage();
                         return;
@@ -86,6 +92,7 @@ public class MinorLeagueArena extends AbstractImageEvent {
                         this.imageEventText.updateBodyText(DESCRIPTIONS[1]);
                         this.imageEventText.clearAllDialogs();
                         this.imageEventText.setDialogOption(OPTIONS[3]);
+                        logMetricIgnored(ID);
                         return;
                     default:
                         return;

--- a/src/main/java/champ/events/TechniqueTome.java
+++ b/src/main/java/champ/events/TechniqueTome.java
@@ -129,7 +129,7 @@ public class TechniqueTome extends AbstractImageEvent {
                             }
                             logMetric(ID, "Read", prideGained > 0 ? curses : null, null, null, cardsTeched,
                                     null, null, null,
-                                    0, 0, hpSpent, 0, 0, 0);
+                                    hpSpent, 0, 0, 0, 0, 0);
 
                         }
 

--- a/src/main/java/champ/events/TechniqueTome.java
+++ b/src/main/java/champ/events/TechniqueTome.java
@@ -12,6 +12,7 @@ import com.megacrit.cardcrawl.actions.AbstractGameAction;
 import com.megacrit.cardcrawl.cards.AbstractCard;
 import com.megacrit.cardcrawl.cards.CardGroup;
 import com.megacrit.cardcrawl.cards.DamageInfo;
+import com.megacrit.cardcrawl.cards.curses.Pride;
 import com.megacrit.cardcrawl.core.CardCrawlGame;
 import com.megacrit.cardcrawl.core.Settings;
 import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
@@ -25,6 +26,7 @@ import downfall.cards.curses.Haunted;
 import downfall.cards.curses.PrideStandard;
 import slimebound.SlimeboundMod;
 
+import java.util.ArrayList;
 import java.util.Iterator;
 
 public class TechniqueTome extends AbstractImageEvent {
@@ -44,6 +46,9 @@ public class TechniqueTome extends AbstractImageEvent {
     private int screenNum = 0;
     private boolean pickCard = false;
     private int hpCost = 5;
+    private int hpSpent = 0;
+    private ArrayList<String> cardsTeched = new ArrayList<>();
+    private int prideGained;
 
     public TechniqueTome() {
         super(NAME, DESCRIPTIONS[0], "champResources/images/events/book.png");
@@ -69,6 +74,8 @@ public class TechniqueTome extends AbstractImageEvent {
             AbstractDungeon.effectsQueue.add(new ShowCardBrieflyEffect(c.makeStatEquivalentCopy()));
             AbstractDungeon.topLevelEffects.add(new UpgradeShineEffect((float) Settings.WIDTH / 2.0F, (float) Settings.HEIGHT / 2.0F));
             AbstractDungeon.gridSelectScreen.selectedCards.clear();
+            cardsTeched.add(c.cardID);
+
             this.pickCard = false;
             if (this.hpCost == 5) {
 
@@ -98,7 +105,9 @@ public class TechniqueTome extends AbstractImageEvent {
                         this.pickCard = true;
                         if (this.hpCost > 20){
                             AbstractDungeon.effectList.add(new ShowCardAndObtainEffect(new PrideStandard(), (float) (Settings.WIDTH / 2), (float) (Settings.HEIGHT / 2)));
+                            prideGained++;
                         } else {
+                            hpSpent += hpCost;
                             AbstractDungeon.player.damage(new DamageInfo(AbstractDungeon.player, this.hpCost));
                             AbstractDungeon.effectList.add(new FlashAtkImgEffect(AbstractDungeon.player.hb.cX, AbstractDungeon.player.hb.cY, AbstractGameAction.AttackEffect.POISON));
                         }
@@ -110,13 +119,21 @@ public class TechniqueTome extends AbstractImageEvent {
                         if (this.hpCost == 5) {
 
                             this.imageEventText.updateBodyText(DESCRIPTIONS[3]);
+                            logMetricIgnored(ID);
                         } else {
 
                             this.imageEventText.updateBodyText(DESCRIPTIONS[4]);
+                            ArrayList<String> curses = new ArrayList<>();
+                            for (int i = 0; i < prideGained; i++) {
+                                curses.add(Pride.ID);
+                            }
+                            logMetric(ID, "Read", prideGained > 0 ? curses : null, null, null, cardsTeched,
+                                    null, null, null,
+                                    0, 0, hpSpent, 0, 0, 0);
+
                         }
 
                         this.imageEventText.updateDialogOption(0, OPTIONS[2]);
-
 
                         this.imageEventText.clearRemainingOptions();
                         return;

--- a/src/main/java/downfall/mainmenu/MainMenuAdPatch.java
+++ b/src/main/java/downfall/mainmenu/MainMenuAdPatch.java
@@ -15,6 +15,7 @@ import com.megacrit.cardcrawl.helpers.TipHelper;
 import com.megacrit.cardcrawl.helpers.input.InputHelper;
 import com.megacrit.cardcrawl.localization.UIStrings;
 import com.megacrit.cardcrawl.scenes.TitleBackground;
+import com.megacrit.cardcrawl.screens.mainMenu.MainMenuScreen;
 import downfall.util.TextureLoader;
 
 import java.awt.*;

--- a/src/main/java/gremlin/events/BackToBasicsGremlin.java
+++ b/src/main/java/gremlin/events/BackToBasicsGremlin.java
@@ -99,6 +99,7 @@ public class BackToBasicsGremlin extends AbstractImageEvent {
             AbstractDungeon.effectList.add(new PurgeCardEffect(c));
             AbstractDungeon.player.masterDeck.removeCard(c);
             AbstractDungeon.gridSelectScreen.selectedCards.remove(c);
+            logMetricCardRemoval(ID, "Elegance", c);
         }
 
     }
@@ -107,15 +108,24 @@ public class BackToBasicsGremlin extends AbstractImageEvent {
         switch (this.screen) {
             case INTRO:
                 if (buttonPressed == 0) {
+                    ArrayList<String> cardsRemoved = new ArrayList<>();
+                    ArrayList<String> cardsAdded = new ArrayList<>();
 
                     for (AbstractCard c : strikesToRemove){
+                        cardsRemoved.add(c.cardID);
+                        cardsAdded.add(Shiv.ID);
                         AbstractDungeon.player.masterDeck.removeCard(c);
                         AbstractDungeon.effectList.add(new ShowCardAndObtainEffect(new Shiv(), (float)Settings.WIDTH / 2.0F, (float)Settings.HEIGHT / 2.0F));
                     }
                     for (AbstractCard c : defendsToRemove){
+                        cardsRemoved.add(c.cardID);
+                        cardsAdded.add(Ward.ID);
                         AbstractDungeon.player.masterDeck.removeCard(c);
                         AbstractDungeon.effectList.add(new ShowCardAndObtainEffect(new Ward(), (float)Settings.WIDTH / 2.0F, (float)Settings.HEIGHT / 2.0F));
                     }
+                    logMetric(ID, "Caprice", cardsAdded, cardsRemoved, null, null,
+                            null, null, null,
+                            0, 0, 0, 0, 0, 0);
 
                     this.imageEventText.updateBodyText(DESCRIPTIONSGUARDIAN[0]);
                     this.imageEventText.updateDialogOption(0, OPTIONS[3]);
@@ -152,6 +162,7 @@ public class BackToBasicsGremlin extends AbstractImageEvent {
                 AbstractDungeon.effectList.add(new ShowCardBrieflyEffect(c.makeStatEquivalentCopy(), MathUtils.random(0.1F, 0.9F) * (float) Settings.WIDTH, MathUtils.random(0.2F, 0.8F) * (float) Settings.HEIGHT));
             }
         }
+        logMetricUpgradeCards(ID, "Simplicity", cardsUpgraded);
     }
 
     private enum CUR_SCREEN {

--- a/src/main/java/gremlin/events/GremlinTrenchcoat.java
+++ b/src/main/java/gremlin/events/GremlinTrenchcoat.java
@@ -7,6 +7,8 @@ import com.megacrit.cardcrawl.events.AbstractImageEvent;
 import com.megacrit.cardcrawl.localization.EventStrings;
 import com.megacrit.cardcrawl.rewards.RewardItem;
 
+import java.util.ArrayList;
+
 public class GremlinTrenchcoat extends AbstractImageEvent {
     public static final String ID = "Gremlin:Trenchcoat";
     private static final EventStrings eventStrings;
@@ -49,6 +51,8 @@ public class GremlinTrenchcoat extends AbstractImageEvent {
 
     private void getColorlessCard(int num) {
         AbstractDungeon.getCurrRoom().rewards.clear();
+        logMetricLoseGold(ID, "Bought " + num + " cards", goldAmount * num);
+
         for (int i=0;i<num;i++) {
             RewardItem reward = new RewardItem(AbstractCard.CardColor.COLORLESS);
             while(reward.cards.size() > 1) {
@@ -82,6 +86,7 @@ public class GremlinTrenchcoat extends AbstractImageEvent {
                         break;
                     case 3:
                         this.imageEventText.updateBodyText(DESCRIPTIONS[2]);
+                        logMetricIgnored(ID);
                 }
 
                 this.imageEventText.updateDialogOption(0, OPTIONS[5]);

--- a/src/main/java/gremlin/events/ScrapOozeGremlins.java
+++ b/src/main/java/gremlin/events/ScrapOozeGremlins.java
@@ -51,10 +51,12 @@ public class ScrapOozeGremlins extends AbstractImageEvent {
                         int random = AbstractDungeon.miscRng.random(0, 99);
                         if (random < this.curseObtainChance) {
                             this.imageEventText.updateBodyText(BIG_FAIL_MSG);
-                            AbstractDungeon.effectList.add(new ShowCardAndObtainEffect(new Scatterbrained(), (float) (Settings.WIDTH / 2), (float) (Settings.HEIGHT / 2)));
+                            Scatterbrained curse = new Scatterbrained();
+                            AbstractDungeon.effectList.add(new ShowCardAndObtainEffect(curse, (float) (Settings.WIDTH / 2), (float) (Settings.HEIGHT / 2)));
                             this.imageEventText.updateDialogOption(0, OPTIONS[3]);
                             this.imageEventText.removeDialogOption(1);
                             this.screenNum = 1;
+                            logMetricObtainCard(ID, "Got Bored", curse);
                         } else if (random >= 99 - this.relicObtainChance) {
                             this.imageEventText.updateBodyText(SUCCESS_MSG);
                             AbstractRelic r = AbstractDungeon.returnRandomScreenlessRelic(AbstractDungeon.returnRandomRelicTier());
@@ -62,6 +64,7 @@ public class ScrapOozeGremlins extends AbstractImageEvent {
                             this.imageEventText.removeDialogOption(1);
                             this.screenNum = 1;
                             AbstractDungeon.getCurrRoom().spawnRelicAndObtain((float)Settings.WIDTH / 2.0F, (float)Settings.HEIGHT / 2.0F, r);
+                            logMetricObtainRelic(ID, "Reached Inside", r);
                         } else {
                             this.imageEventText.updateBodyText(FAIL_MSG);
                             this.curseObtainChance += 5;
@@ -79,6 +82,7 @@ public class ScrapOozeGremlins extends AbstractImageEvent {
                         this.imageEventText.updateDialogOption(0, OPTIONS[3]);
                         this.imageEventText.removeDialogOption(1);
                         this.screenNum = 1;
+                        logMetricIgnored(ID);
                         return;
                     default:
                         return;

--- a/src/main/java/guardian/events/GemMine.java
+++ b/src/main/java/guardian/events/GemMine.java
@@ -148,7 +148,7 @@ public class GemMine extends AbstractImageEvent {
                         this.imageEventText.clearRemainingOptions();
                         if(cardsAdded.size() > 0 || relicsAdded.size() > 0 || damageTaken > 0) {
                             logMetric(ID, "Entered Mine", cardsAdded, null, null, null, relicsAdded, null, null,
-                                    0, 0, damageTaken, 0, 0, 0);
+                                    damageTaken, 0, 0, 0, 0, 0);
                         } else {
                             logMetricIgnored(ID);
                         }

--- a/src/main/java/slimebound/events/ArtOfSlimeWar.java
+++ b/src/main/java/slimebound/events/ArtOfSlimeWar.java
@@ -22,6 +22,7 @@ import slimebound.cards.CheckThePlaybook;
 import downfall.cards.curses.Icky;
 import slimebound.cards.Tackle;
 
+import java.util.ArrayList;
 import java.util.Iterator;
 
 public class ArtOfSlimeWar extends AbstractImageEvent {
@@ -115,9 +116,12 @@ public class ArtOfSlimeWar extends AbstractImageEvent {
                         this.screenNum = 2;
                         this.imageEventText.updateDialogOption(0, OPTIONS[2]);
                         this.imageEventText.clearRemainingOptions();
+                        logMetricIgnored(ID);
                         return;
                 }
             case 1:
+                ArrayList<String> cards = new ArrayList<>();
+                cards.add(CheckThePlaybook.ID);
                 switch (buttonPressed) {
                     case 0:
                         CardCrawlGame.screenShake.shake(ShakeIntensity.MED, ShakeDur.MED, false);
@@ -128,6 +132,8 @@ public class ArtOfSlimeWar extends AbstractImageEvent {
                         this.screenNum = 2;
                         this.imageEventText.updateDialogOption(0, OPTIONS[2]);
                         this.imageEventText.clearRemainingOptions();
+                        cards.add(curse.cardID);
+                        logMetricObtainCards(ID, "Dive", cards);
                         return;
                     case 1:
                         this.imageEventText.updateBodyText(DIALOG_CHOSE_FIGHT);
@@ -137,6 +143,7 @@ public class ArtOfSlimeWar extends AbstractImageEvent {
                         this.screenNum = 2;
                         this.imageEventText.updateDialogOption(0, OPTIONS[2]);
                         this.imageEventText.clearRemainingOptions();
+                        logMetricObtainCardAndDamage(ID, "Be Patient", new CheckThePlaybook(), damage);
                         return;
                     case 2:
                         this.imageEventText.updateBodyText(DIALOG_CHOSE_FLAT);
@@ -146,6 +153,7 @@ public class ArtOfSlimeWar extends AbstractImageEvent {
                         this.screenNum = 2;
                         this.imageEventText.updateDialogOption(0, OPTIONS[2]);
                         this.imageEventText.clearRemainingOptions();
+                        logMetricObtainCardsLoseMapHP(ID, "Grab and Run", cards, maxHpLoss);
                         return;
                     default:
                         this.openMap();
@@ -162,6 +170,8 @@ public class ArtOfSlimeWar extends AbstractImageEvent {
 
     private void replaceAttacks() {
         Iterator i = AbstractDungeon.player.masterDeck.group.iterator();
+        ArrayList<String> cardsRemoved = new ArrayList<>();
+        ArrayList<String> cardsAdded = new ArrayList<>();
 
         while (true) {
             AbstractCard e;
@@ -170,13 +180,17 @@ public class ArtOfSlimeWar extends AbstractImageEvent {
                     for (int i2 = 0; i2 < 3; ++i2) {
                         AbstractCard c = new Tackle();
                         c.upgrade();
+                        cardsAdded.add(c.cardID);
                         AbstractDungeon.effectList.add(new ShowCardAndObtainEffect(c, (float) Settings.WIDTH / 2.0F, (float) Settings.HEIGHT / 2.0F));
                     }
-
+                    logMetric(ID, "Read", cardsAdded, cardsRemoved, null, null,
+                            null, null, null,
+                            0, 0, 0, 0, 0, 0);
                     return;
                 }
 
                 e = (AbstractCard) i.next();
+                cardsRemoved.add(e.cardID);
             } while (!(e.hasTag(BaseModCardTags.BASIC_STRIKE)));
 
             i.remove();

--- a/src/main/java/slimebound/events/BackToBasicsSlime.java
+++ b/src/main/java/slimebound/events/BackToBasicsSlime.java
@@ -105,6 +105,7 @@ public class BackToBasicsSlime extends AbstractImageEvent {
             AbstractDungeon.effectList.add(new PurgeCardEffect(c));
             AbstractDungeon.player.masterDeck.removeCard(c);
             AbstractDungeon.gridSelectScreen.selectedCards.remove(c);
+            logMetricCardRemoval(ID, "Elegance", c);
         }
 
     }
@@ -113,10 +114,13 @@ public class BackToBasicsSlime extends AbstractImageEvent {
         switch (this.screen) {
             case INTRO:
                 if (buttonPressed == 0) {
+                    ArrayList<String> cardsCommanded = new ArrayList<>();
 
                     for (AbstractCard c : cardsToRemove){
                         CardModifierManager.addModifier(c, new CommandMod());
-                   }
+                        cardsCommanded.add(c.cardID);
+                    }
+                    logMetricUpgradeCards(ID, "Inspiration", cardsCommanded);
 
                     this.imageEventText.updateBodyText(DESCRIPTIONSGUARDIAN[0]);
                     this.imageEventText.updateDialogOption(0, OPTIONS[3]);
@@ -153,6 +157,7 @@ public class BackToBasicsSlime extends AbstractImageEvent {
                 AbstractDungeon.effectList.add(new ShowCardBrieflyEffect(c.makeStatEquivalentCopy(), MathUtils.random(0.1F, 0.9F) * (float) Settings.WIDTH, MathUtils.random(0.2F, 0.8F) * (float) Settings.HEIGHT));
             }
         }
+        logMetricUpgradeCards(ID, "Simplicity", cardsUpgraded);
     }
 
     private enum CUR_SCREEN {

--- a/src/main/java/slimebound/events/DarklingsSlimebound.java
+++ b/src/main/java/slimebound/events/DarklingsSlimebound.java
@@ -19,6 +19,7 @@ import org.apache.logging.log4j.Logger;
 import slimebound.cards.Darklings;
 
 import java.util.ArrayList;
+import java.util.Collections;
 
 public class DarklingsSlimebound extends AbstractEvent {
     private static final Logger logger = LogManager.getLogger(DarklingsSlimebound.class.getName());
@@ -64,6 +65,7 @@ public class DarklingsSlimebound extends AbstractEvent {
         switch (buttonPressed) {// 62
             case 0:
                 if (this.screenNum == 0) {// 65
+                    logMetric(ID, "Fight");
                     AbstractDungeon.getCurrRoom().monsters = MonsterHelper.getEncounter("3 Darklings");// 66
                     this.roomEventText.updateBodyText(DESCRIPTIONS[1]);// 68
                     this.roomEventText.updateDialogOption(0, OPTIONS[2]);// 69
@@ -78,13 +80,15 @@ public class DarklingsSlimebound extends AbstractEvent {
                 return;// 92
             case 1:
                 AbstractCard bonus = new Darklings();// 956
+                AbstractCard cardRemoved = validCards.get(0);
                 AbstractDungeon.effectList.add(new com.megacrit.cardcrawl.vfx.cardManip.PurgeCardEffect(
+                        cardRemoved, Settings.WIDTH * 0.35F, com.megacrit.cardcrawl.core.Settings.HEIGHT / 2));
 
-                        (AbstractCard) validCards.get(0), Settings.WIDTH * 0.35F, com.megacrit.cardcrawl.core.Settings.HEIGHT / 2));
 
-
-                AbstractDungeon.player.masterDeck.removeCard((AbstractCard) validCards.get(0));
-
+                AbstractDungeon.player.masterDeck.removeCard(cardRemoved);
+                logMetric(ID, "Recruit", Collections.singletonList(bonus.cardID), Collections.singletonList(cardRemoved.cardID), null, null,
+                        null, null, null,
+                        0, 0, 0, 0, 0, 0);
                 AbstractDungeon.effectList.add(new ShowCardAndObtainEffect(bonus, (float) Settings.WIDTH * 0.65F, (float) Settings.HEIGHT / 2.0F));// 99
                 this.roomEventText.updateBodyText(DESCRIPTIONS[2]);// 101
                 this.roomEventText.updateDialogOption(0, OPTIONS[2]);// 102

--- a/src/main/java/slimebound/events/ScrapOozeSlimebound.java
+++ b/src/main/java/slimebound/events/ScrapOozeSlimebound.java
@@ -95,7 +95,7 @@ public class ScrapOozeSlimebound extends AbstractImageEvent {
                         if (random >= 99 - this.relicObtainChance) {
                             this.imageEventText.updateBodyText(SUCCESS_MSG);
                             AbstractRelic r = AbstractDungeon.returnRandomScreenlessRelic(AbstractDungeon.returnRandomRelicTier());
-                            AbstractEvent.logMetricObtainRelicAndDamage("Scrap Ooze", "Success", r, this.totalDamageDealt);
+                            AbstractEvent.logMetricObtainRelicAndDamage(ID, "Success", r, this.totalDamageDealt);
                             this.imageEventText.clearAllDialogs();
                             this.imageEventText.setDialogOption(OPTIONS[3]);
                             this.screenNum = 1;
@@ -113,13 +113,15 @@ public class ScrapOozeSlimebound extends AbstractImageEvent {
                     case 1:
                         AbstractDungeon.player.loseRelic(this.relicOffered.relicId);
                         imageEventText.updateBodyText(DESCRIPTIONSALT[0]);
-                        AbstractDungeon.getCurrRoom().spawnRelicAndObtain(Settings.WIDTH / 2.0f, Settings.HEIGHT / 2.0f, RelicLibrary.getRelic(ScrapOozeRelic.ID).makeCopy());
+                        AbstractRelic relic = RelicLibrary.getRelic(ScrapOozeRelic.ID).makeCopy();
+                        AbstractDungeon.getCurrRoom().spawnRelicAndObtain(Settings.WIDTH / 2.0f, Settings.HEIGHT / 2.0f, relic);
                         this.imageEventText.clearAllDialogs();
                         this.imageEventText.setDialogOption(OPTIONS[3]);
                         this.screenNum = 1;
+                        logMetricRelicSwap(ID, "Recruit", relic, this.relicOffered);
                         return;
                     case 2:
-                        AbstractEvent.logMetricTakeDamage("Scrap Ooze", "Fled", this.totalDamageDealt);
+                        AbstractEvent.logMetricTakeDamage(ID, "Fled", this.totalDamageDealt);
                         this.imageEventText.updateBodyText(ESCAPE_MSG);
                         this.imageEventText.clearAllDialogs();
                         this.imageEventText.setDialogOption(OPTIONS[3]);

--- a/src/main/java/slimebound/events/WorldOfGoopSlimebound.java
+++ b/src/main/java/slimebound/events/WorldOfGoopSlimebound.java
@@ -11,6 +11,7 @@ import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
 import com.megacrit.cardcrawl.events.AbstractImageEvent;
 import com.megacrit.cardcrawl.helpers.RelicLibrary;
 import com.megacrit.cardcrawl.localization.EventStrings;
+import com.megacrit.cardcrawl.relics.AbstractRelic;
 import com.megacrit.cardcrawl.vfx.RainingGoldEffect;
 import slimebound.relics.GreedOozeRelic;
 
@@ -75,17 +76,20 @@ public class WorldOfGoopSlimebound extends AbstractImageEvent {
                         AbstractDungeon.player.gainGold(this.gold);
                         imageEventText.updateBodyText(GOLD_DIALOG);
                         this.screen = WorldOfGoopSlimebound.CurScreen.RESULT;
+                        logMetricGainGold(ID, "Gather Souls", gold);
                         return;
                     case 1:
                         imageEventText.updateBodyText(LEAVE_DIALOG);
                         this.imageEventText.clearAllDialogs();
                         this.imageEventText.setDialogOption(OPTIONS[2]);
-                        AbstractDungeon.getCurrRoom().spawnRelicAndObtain(Settings.WIDTH / 2.0f, Settings.HEIGHT / 2.0f, RelicLibrary.getRelic(GreedOozeRelic.ID).makeCopy());
+                        AbstractRelic relic = RelicLibrary.getRelic(GreedOozeRelic.ID).makeCopy();
+                        AbstractDungeon.getCurrRoom().spawnRelicAndObtain(Settings.WIDTH / 2.0f, Settings.HEIGHT / 2.0f, relic);
                         AbstractDungeon.player.loseGold(this.gold);
                         this.screen = WorldOfGoopSlimebound.CurScreen.RESULT;
+                        logMetricObtainRelicAtCost(ID, "Recruit", relic, gold);
                         return;
                     default:
-
+                        logMetricIgnored(ID);
                         return;
                 }
             default:

--- a/src/main/java/sneckomod/events/BackToBasicsSnecko.java
+++ b/src/main/java/sneckomod/events/BackToBasicsSnecko.java
@@ -110,6 +110,7 @@ public class BackToBasicsSnecko extends AbstractImageEvent {
             AbstractDungeon.effectList.add(new PurgeCardEffect(c));
             AbstractDungeon.player.masterDeck.removeCard(c);
             AbstractDungeon.gridSelectScreen.selectedCards.remove(c);
+            logMetricCardRemoval(ID, "Elegance", c);
         }
 
     }
@@ -132,16 +133,21 @@ public class BackToBasicsSnecko extends AbstractImageEvent {
                             }
                         }
                     }
+                    ArrayList<String> cardsRemoved = new ArrayList<>();
+                    ArrayList<String> cardsAdded = new ArrayList<>();
 
                     for (AbstractCard c : cardsToRemove) {
                         Collections.shuffle(list);
                         AbstractCard cU = list.get(0);
+                        cardsAdded.add(cU.cardID);
                         AbstractDungeon.effectList.add(new ShowCardAndObtainEffect(cU.makeStatEquivalentCopy(), (Settings.WIDTH / 2F), (float) (Settings.HEIGHT / 2)));
                     }
 
                     for (AbstractCard c : cardsToRemove) {
                         AbstractDungeon.player.masterDeck.removeCard(c);
+                        cardsRemoved.add(c.cardID);
                     }
+                    logMetricTransformCards(ID, "Improvisation", cardsAdded, cardsRemoved);
 
                     this.imageEventText.updateBodyText(DESCRIPTIONSGUARDIAN[0]);
                     this.imageEventText.updateDialogOption(0, OPTIONS[3]);
@@ -178,6 +184,7 @@ public class BackToBasicsSnecko extends AbstractImageEvent {
                 AbstractDungeon.effectList.add(new ShowCardBrieflyEffect(c.makeStatEquivalentCopy(), MathUtils.random(0.1F, 0.9F) * (float) Settings.WIDTH, MathUtils.random(0.2F, 0.8F) * (float) Settings.HEIGHT));
             }
         }
+        logMetricUpgradeCards(ID, "Simplicity", cardsUpgraded);
     }
 
     private enum CUR_SCREEN {

--- a/src/main/java/sneckomod/events/D8.java
+++ b/src/main/java/sneckomod/events/D8.java
@@ -73,12 +73,14 @@ public class D8 extends AbstractImageEvent {
                         for (AbstractCard c : CardLibrary.getAllCards()) {
                             if (c instanceof AbstractUnknownCard)
                                 list.add(c);
+
                         }
                         Collections.shuffle(list);
 
                         int times = 0;
+                        ArrayList<String> cardsAdded = new ArrayList<>();
                         for (AbstractCard c : list) {
-
+                            cardsAdded.add(c.cardID);
                             AbstractDungeon.effectList.add(new ShowCardAndObtainEffect(c, (float) (Settings.WIDTH * (0.1 + (0.2 * times))), (float) (Settings.HEIGHT / 2)));
                             times++;
                             if (times == 5) break;
@@ -91,22 +93,29 @@ public class D8 extends AbstractImageEvent {
                         this.imageEventText.updateBodyText(DESCRIPTIONS[1]);
                         this.screen = CurScreen.END;
                         list.clear();
+                        logMetric(ID, "Shatter", cardsAdded, null, null, null,
+                                null, null, null,
+                                finalDmg, 0, 0, 0, 0, 0);
                         break;
                     case 1:
 
-                        AbstractDungeon.effectList.add(new ShowCardAndObtainEffect(new Pain(), (float) Settings.WIDTH / 2.0F, (float) Settings.HEIGHT / 2.0F));
-                        AbstractDungeon.getCurrRoom().spawnRelicAndObtain((float) (Settings.WIDTH / 2), (float) (Settings.HEIGHT / 2), new sneckomod.relics.D8());
+                        Pain curse = new Pain();
+                        AbstractDungeon.effectList.add(new ShowCardAndObtainEffect(curse, (float) Settings.WIDTH / 2.0F, (float) Settings.HEIGHT / 2.0F));
+                        sneckomod.relics.D8 relic = new sneckomod.relics.D8();
+                        AbstractDungeon.getCurrRoom().spawnRelicAndObtain((float) (Settings.WIDTH / 2), (float) (Settings.HEIGHT / 2), relic);
 
                         this.imageEventText.clearAllDialogs();
                         this.imageEventText.setDialogOption(OPTIONS[3]);
                         this.imageEventText.updateBodyText(DESCRIPTIONS[2]);
                         this.screen = CurScreen.END;
+                        logMetricObtainCardAndRelic(ID, "Take", curse, relic);
                         return;
                     case 2:
                         this.imageEventText.clearAllDialogs();
                         this.imageEventText.setDialogOption(OPTIONS[3]);
                         this.imageEventText.updateBodyText(DESCRIPTIONS[3]);
                         this.screen = CurScreen.END;
+                        logMetricIgnored(ID);
                         return;
                 }
 

--- a/src/main/java/sneckomod/events/Serpent_Snecko.java
+++ b/src/main/java/sneckomod/events/Serpent_Snecko.java
@@ -69,13 +69,14 @@ public class Serpent_Snecko extends AbstractImageEvent {
 
                     com.megacrit.cardcrawl.relics.AbstractRelic r = AbstractDungeon.returnRandomScreenlessRelic(AbstractDungeon.returnRandomRelicTier());
                     AbstractDungeon.getCurrRoom().spawnRelicAndObtain(Settings.WIDTH / 2, Settings.HEIGHT / 2, r);
-
+                    logMetricObtainCardAndRelic(ID, "Agree", curse, r);
                     this.screen = CUR_SCREEN.AGREE;
                 } else {
                     this.imageEventText.updateBodyText(DISAGREE_DIALOG);
                     this.imageEventText.removeDialogOption(1);
                     this.imageEventText.updateDialogOption(0, OPTIONS[2]);
                     this.screen = CUR_SCREEN.DISAGREE;
+                    logMetricIgnored(ID);
                 }
                 break;
             default:

--- a/src/main/java/sneckomod/events/SuspiciousHouse.java
+++ b/src/main/java/sneckomod/events/SuspiciousHouse.java
@@ -41,18 +41,22 @@ public class SuspiciousHouse extends AbstractImageEvent {
                 this.imageEventText.clearAllDialogs();
                 switch (buttonPressed) {
                     case 0:
-                        AbstractDungeon.effectList.add(new ShowCardAndObtainEffect(new Bewildered(), (float) Settings.WIDTH / 2.0F, (float) Settings.HEIGHT / 2.0F));
-                        AbstractDungeon.getCurrRoom().spawnRelicAndObtain((float) (Settings.WIDTH / 2), (float) (Settings.HEIGHT / 2), new sneckomod.relics.BabySnecko());
+                        Bewildered curse = new Bewildered();
+                        AbstractDungeon.effectList.add(new ShowCardAndObtainEffect(curse, (float) Settings.WIDTH / 2.0F, (float) Settings.HEIGHT / 2.0F));
+                        BabySnecko relic = new BabySnecko();
+                        AbstractDungeon.getCurrRoom().spawnRelicAndObtain((float) (Settings.WIDTH / 2), (float) (Settings.HEIGHT / 2), relic);
                         this.imageEventText.clearAllDialogs();
                         this.imageEventText.setDialogOption(OPTIONS[1]);
                         this.imageEventText.updateBodyText(DESCRIPTIONS[1]);
                         this.screen = CurScreen.END;
+                        logMetricObtainCardAndRelic(ID, "Rescued", curse, relic);
                         return;
                     case 2:
                         this.imageEventText.clearAllDialogs();
                         this.imageEventText.setDialogOption(OPTIONS[1]);
                         this.imageEventText.updateBodyText(DESCRIPTIONS[2]);
                         this.screen = CurScreen.END;
+                        logMetricIgnored(ID);
                         return;
                 }
 

--- a/src/main/java/theHexaghost/events/BackToBasicsHexaghost.java
+++ b/src/main/java/theHexaghost/events/BackToBasicsHexaghost.java
@@ -107,6 +107,7 @@ public class BackToBasicsHexaghost extends AbstractImageEvent {
             AbstractDungeon.effectList.add(new PurgeCardEffect(c));
             AbstractDungeon.player.masterDeck.removeCard(c);
             AbstractDungeon.gridSelectScreen.selectedCards.remove(c);
+            logMetricCardRemoval(ID, "Elegance", c);
         }
 
     }
@@ -118,7 +119,9 @@ public class BackToBasicsHexaghost extends AbstractImageEvent {
 
                     for (AbstractCard c : cardsToRemove){
                         CardModifierManager.addModifier(c, new EtherealMod());
-                   }
+                        cardsUpgraded.add(c.cardID);
+                    }
+                    logMetricUpgradeCards(ID, "Wistfulness", cardsUpgraded);
 
                     this.imageEventText.updateBodyText(DESCRIPTIONSGUARDIAN[0]);
                     this.imageEventText.updateDialogOption(0, OPTIONS[3]);
@@ -155,6 +158,7 @@ public class BackToBasicsHexaghost extends AbstractImageEvent {
                 AbstractDungeon.effectList.add(new ShowCardBrieflyEffect(c.makeStatEquivalentCopy(), MathUtils.random(0.1F, 0.9F) * (float) Settings.WIDTH, MathUtils.random(0.2F, 0.8F) * (float) Settings.HEIGHT));
             }
         }
+        logMetricUpgradeCards(ID, "Simplicity", cardsUpgraded);
     }
 
     private enum CUR_SCREEN {

--- a/src/main/java/theHexaghost/events/CouncilOfGhosts_Hexa.java
+++ b/src/main/java/theHexaghost/events/CouncilOfGhosts_Hexa.java
@@ -24,6 +24,7 @@ import theHexaghost.cards.seals.SecondSeal;
 import theHexaghost.cards.seals.ThirdSeal;
 
 import java.util.ArrayList;
+import java.util.List;
 
 public class CouncilOfGhosts_Hexa extends AbstractImageEvent {
     public static final String ID = HexaMod.makeID("CouncilOfGhosts");
@@ -44,6 +45,10 @@ public class CouncilOfGhosts_Hexa extends AbstractImageEvent {
     private int hpLoss;
 
     private boolean accept = false;
+    private List<String> cardsRemoved = new ArrayList<>();
+    private List<String> cardsAdded = new ArrayList<>();
+
+
 
     public CouncilOfGhosts_Hexa() {
         super(NAME, DESCRIPTIONS[0], "images/events/ghost.jpg");
@@ -100,8 +105,8 @@ public class CouncilOfGhosts_Hexa extends AbstractImageEvent {
                         nukeStrikes();
                         for (int i = 0; i < 3; i++) {
                             AbstractCard n = new CouncilsJustice();
-//                            AbstractDungeon.player.masterDeck.addToTop(n);
-                            AbstractDungeon.effectList.add(new ShowCardAndObtainEffect(new CouncilsJustice(), Settings.WIDTH * (AbstractDungeon.cardRng.random(0.25F,0.75F)), Settings.HEIGHT * (AbstractDungeon.cardRng.random(0.25F,0.75F))));
+                            cardsAdded.add(n.cardID);
+                            AbstractDungeon.effectList.add(new ShowCardAndObtainEffect(n, Settings.WIDTH * (AbstractDungeon.cardRng.random(0.25F,0.75F)), Settings.HEIGHT * (AbstractDungeon.cardRng.random(0.25F,0.75F))));
                         }
                         return;
                     case 2:
@@ -111,8 +116,8 @@ public class CouncilOfGhosts_Hexa extends AbstractImageEvent {
                         nukeDefends();
                         for (int i = 0; i < 3; i++) {
                             AbstractCard n = new Apparition();
-//                            AbstractDungeon.player.masterDeck.addToTop(n);
-                            AbstractDungeon.effectList.add(new ShowCardAndObtainEffect(new Apparition(), Settings.WIDTH * (AbstractDungeon.cardRng.random(0.25F,0.75F)), Settings.HEIGHT * (AbstractDungeon.cardRng.random(0.25F,0.75F))));
+                            cardsAdded.add(n.cardID);
+                            AbstractDungeon.effectList.add(new ShowCardAndObtainEffect(n, Settings.WIDTH * (AbstractDungeon.cardRng.random(0.25F,0.75F)), Settings.HEIGHT * (AbstractDungeon.cardRng.random(0.25F,0.75F))));
                         }
                         return;
                     case 3:
@@ -120,8 +125,12 @@ public class CouncilOfGhosts_Hexa extends AbstractImageEvent {
                         this.imageEventText.setDialogOption(OPTIONS[5]);
                         if (this.accept){
                             this.imageEventText.updateBodyText(DESCRIPTIONS[4]);
+                            logMetric(ID, "Accepted", cardsAdded, cardsRemoved, null, null,
+                                    null, null, null,
+                                    0, 0, hpLoss, 0, 0, 0);
                         } else {
                             this.imageEventText.updateBodyText(DESCRIPTIONS[5]);
+                            logMetricIgnored(ID);
                         }
                         this.screen = CurScreen.END;
                         return;
@@ -143,7 +152,7 @@ public class CouncilOfGhosts_Hexa extends AbstractImageEvent {
         for (AbstractCard c : strikes){
             AbstractDungeon.topLevelEffects.add(new com.megacrit.cardcrawl.vfx.cardManip.PurgeCardEffect(c, com.megacrit.cardcrawl.core.Settings.WIDTH * (AbstractDungeon.cardRng.random(0.25F,0.75F)), com.megacrit.cardcrawl.core.Settings.HEIGHT * (AbstractDungeon.cardRng.random(0.25F,0.75F))));
             AbstractDungeon.player.masterDeck.removeCard(c);
-
+            cardsRemoved.add(c.cardID);
         }
     }
 
@@ -158,6 +167,7 @@ public class CouncilOfGhosts_Hexa extends AbstractImageEvent {
         for (AbstractCard c : defends){
             AbstractDungeon.topLevelEffects.add(new com.megacrit.cardcrawl.vfx.cardManip.PurgeCardEffect(c, com.megacrit.cardcrawl.core.Settings.WIDTH * (AbstractDungeon.cardRng.random(0.25F,0.75F)), com.megacrit.cardcrawl.core.Settings.HEIGHT * (AbstractDungeon.cardRng.random(0.25F,0.75F))));
             AbstractDungeon.player.masterDeck.removeCard(c);
+            cardsRemoved.add(c.cardID);
 
         }
     }

--- a/src/main/java/theHexaghost/events/HexaFalling.java
+++ b/src/main/java/theHexaghost/events/HexaFalling.java
@@ -40,6 +40,7 @@ public class HexaFalling extends AbstractImageEvent {
                     this.imageEventText.setDialogOption(OPTIONS[1]);
                     this.imageEventText.updateBodyText(DESCRIPTIONS[0]);
                     this.screen = CurScreen.END;
+                    logMetric(ID, "Float");
                 }
                 break;
             case END:

--- a/src/main/java/theHexaghost/events/SealChamber.java
+++ b/src/main/java/theHexaghost/events/SealChamber.java
@@ -94,6 +94,12 @@ public class SealChamber extends AbstractImageEvent {
         return (AbstractCard) list.get(0);
     }
 
+    private ArrayList<String> cardsRemoved = new ArrayList<>();
+    private ArrayList<String> cardsObtained = new ArrayList<>();
+    private int goldLost = 0;
+    private int damageTaken = 0;
+
+
     protected void buttonEffect(int buttonPressed) {
         switch (this.screen) {
             case INTRO:
@@ -105,6 +111,8 @@ public class SealChamber extends AbstractImageEvent {
                         this.imageEventText.updateBodyText(DESCRIPTIONS[1]);
                         this.screen = CurScreen.INTRO;
                         used = true;
+                        damageTaken = hpLoss;
+                        cardsObtained.add(FirstSeal.ID);
                         return;
                     case 1:
                         AbstractDungeon.effectList.add(new RainingGoldEffect(this.goldLoss));
@@ -115,6 +123,8 @@ public class SealChamber extends AbstractImageEvent {
                         this.imageEventText.updateBodyText(DESCRIPTIONS[1]);
                         this.screen = CurScreen.INTRO;
                         used = true;
+                        goldLost = goldLoss;
+                        cardsObtained.add(SecondSeal.ID);
                         return;
                     case 2:
                         AbstractDungeon.topLevelEffects.add(new com.megacrit.cardcrawl.vfx.cardManip.PurgeCardEffect(this.cardOption, Settings.WIDTH / 2.0F, Settings.HEIGHT / 2.0F));
@@ -125,6 +135,8 @@ public class SealChamber extends AbstractImageEvent {
                         this.imageEventText.updateBodyText(DESCRIPTIONS[1]);
                         this.screen = CurScreen.INTRO;
                         used = true;
+                        cardsObtained.add(ThirdSeal.ID);
+                        cardsRemoved.add(this.cardOption.cardID);
                         return;
                     case 3:
                         AbstractDungeon.player.removePotion(this.potionOption);
@@ -134,6 +146,7 @@ public class SealChamber extends AbstractImageEvent {
                         this.imageEventText.updateBodyText(DESCRIPTIONS[1]);
                         this.screen = CurScreen.INTRO;
                         used = true;
+                        cardsObtained.add(FourthSeal.ID);
                         return;
                     case 4:
                         this.imageEventText.clearAllDialogs();
@@ -141,8 +154,11 @@ public class SealChamber extends AbstractImageEvent {
                         this.imageEventText.setDialogOption(OPTIONS[8]);
                         if (!used) {
                             this.imageEventText.updateBodyText(DESCRIPTIONS[2]);
+                            logMetricIgnored(ID);
                         } else {
-
+                            logMetric(ID, "Entered Chamber", cardsObtained, cardsRemoved, null, null,
+                                    null, null, null,
+                                    damageTaken, 0, 0, 0, 0, goldLost);
                             this.imageEventText.updateBodyText(DESCRIPTIONS[3]);
                         }
                         return;

--- a/src/main/java/theHexaghost/events/WanderingSpecter.java
+++ b/src/main/java/theHexaghost/events/WanderingSpecter.java
@@ -21,6 +21,7 @@ import theHexaghost.HexaMod;
 import downfall.cards.curses.Haunted;
 
 import java.util.ArrayList;
+import java.util.List;
 
 public class WanderingSpecter extends AbstractImageEvent {
     public static final String ID = HexaMod.makeID("WanderingSpecter");
@@ -80,6 +81,11 @@ public class WanderingSpecter extends AbstractImageEvent {
             this.imageEventText.setDialogOption(OPTIONS[4]);
         }
     }
+    private List<String> relicsAdded = new ArrayList<>();
+    private List<String> cardsAdded = new ArrayList<>();
+    private int maxHpAdded = 0;
+    private int goldAdded = 0;
+
 
     protected void buttonEffect(int buttonPressed) {
         switch (this.screen) {
@@ -92,6 +98,9 @@ public class WanderingSpecter extends AbstractImageEvent {
 
                             AbstractDungeon.getCurrRoom().spawnRelicAndObtain((float) (Settings.WIDTH / 2), (float) (Settings.HEIGHT / 2), rtog);// 83
                             downfallMod.removeAnyRelicFromPools(rtog.relicId);
+                            relicsAdded.add(rtog.relicId);
+                            cardsAdded.add(Haunted.ID);
+                            cardsAdded.add(Haunted.ID);
                         }
                         this.imageEventText.clearAllDialogs();
                         this.imageEventText.setDialogOption(OPTIONS[5]);
@@ -109,6 +118,8 @@ public class WanderingSpecter extends AbstractImageEvent {
                             } else {
                                 downfallMod.removeAnyRelicFromPools(CursedKey.ID);
                             }
+                            relicsAdded.add(rtog2.relicId);
+
                         }
                         this.imageEventText.clearAllDialogs();
                         this.imageEventText.setDialogOption(OPTIONS[5]);
@@ -134,33 +145,47 @@ public class WanderingSpecter extends AbstractImageEvent {
                         this.imageEventText.clearAllDialogs();
                         this.imageEventText.setDialogOption(OPTIONS[9]);
                         this.screen = CurScreen.END;
+                        logMetricObtainRelicAndDamage(ID, "Chased Away", new BlueCandle(), 5);
                         return;
                 }
                 return;
             case TRADE:
+                AbstractCard curse;
                 switch (buttonPressed) {
                     case 0:
-                        AbstractDungeon.effectList.add(new ShowCardAndObtainEffect(CardLibrary.getCurse().makeStatEquivalentCopy(), (float) (Settings.WIDTH * .3F), (float) (Settings.HEIGHT / 2)));// 66
-                        AbstractDungeon.effectList.add(new ShowCardAndObtainEffect(AbstractDungeon.getCard(AbstractCard.CardRarity.RARE,AbstractDungeon.cardRng).makeStatEquivalentCopy(), (float) (Settings.WIDTH * .7F), (float) (Settings.HEIGHT / 2)));// 66
+                        curse = CardLibrary.getCurse().makeStatEquivalentCopy();
+                        AbstractDungeon.effectList.add(new ShowCardAndObtainEffect(curse, (float) (Settings.WIDTH * .3F), (float) (Settings.HEIGHT / 2)));// 66
+                        AbstractCard rareCard = AbstractDungeon.getCard(AbstractCard.CardRarity.RARE, AbstractDungeon.cardRng).makeStatEquivalentCopy();
+                        AbstractDungeon.effectList.add(new ShowCardAndObtainEffect(rareCard, (float) (Settings.WIDTH * .7F), (float) (Settings.HEIGHT / 2)));// 66
 
                         this.imageEventText.updateDialogOption(0, OPTIONS[8], true);
                         this.imageEventText.updateBodyText(DESCRIPTIONS[3]);
 
+                        cardsAdded.add(curse.cardID);
+                        cardsAdded.add(rareCard.cardID);
+
                         return;
                     case 1:
-                        AbstractDungeon.effectList.add(new ShowCardAndObtainEffect(CardLibrary.getCurse().makeStatEquivalentCopy(), (float) (Settings.WIDTH * .5F), (float) (Settings.HEIGHT / 2)));// 66
+                        curse = CardLibrary.getCurse().makeStatEquivalentCopy();
+                        AbstractDungeon.effectList.add(new ShowCardAndObtainEffect(curse, (float) (Settings.WIDTH * .5F), (float) (Settings.HEIGHT / 2)));// 66
                         AbstractDungeon.player.increaseMaxHp(5, true);
                         this.imageEventText.updateDialogOption(1, OPTIONS[8], true);
 
                         this.imageEventText.updateBodyText(DESCRIPTIONS[4]);
+                        cardsAdded.add(curse.cardID);
+                        maxHpAdded = 5;
 
                         return;
                     case 2:
-                        AbstractDungeon.effectList.add(new ShowCardAndObtainEffect(CardLibrary.getCurse().makeStatEquivalentCopy(), (float) (Settings.WIDTH * .5F), (float) (Settings.HEIGHT / 2)));// 66
+                        curse = CardLibrary.getCurse().makeStatEquivalentCopy();
+                        AbstractDungeon.effectList.add(new ShowCardAndObtainEffect(curse, (float) (Settings.WIDTH * .5F), (float) (Settings.HEIGHT / 2)));// 66
                         AbstractDungeon.effectList.add(new RainingGoldEffect(100));
                         AbstractDungeon.player.gainGold(100);
                         this.imageEventText.updateDialogOption(2, OPTIONS[8], true);
                         this.imageEventText.updateBodyText(DESCRIPTIONS[2]);
+
+                        cardsAdded.add(curse.cardID);
+                        goldAdded = 100;
 
                         return;
                     case 3:
@@ -168,6 +193,9 @@ public class WanderingSpecter extends AbstractImageEvent {
                         this.imageEventText.setDialogOption(OPTIONS[9]);
                         this.imageEventText.updateBodyText(DESCRIPTIONS[1]);
                         this.screen = CurScreen.END;
+                        logMetric(ID, "Took Box", cardsAdded, null, null, null,
+                                relicsAdded, null, null,
+                                0, 0, 0, maxHpAdded, goldAdded, 0);
                         return;
                 }
                 return;

--- a/src/main/resources/slimeboundResources/localization/eng/EventStrings.json
+++ b/src/main/resources/slimeboundResources/localization/eng/EventStrings.json
@@ -14,13 +14,13 @@
   "Slimebound:WorldofGoop": {
     "NAME": "World of Goop",
     "DESCRIPTIONS": [
-      "You fall into a puddle. NL @IT'S@ @MADE@ @OF@ #g@SLIME@ #g@GOOP!!@ NL Calmly, you bathe yourself as you bond with the goop, enjoying a moment of reprieve. NL NL Climbing out, you notice in the pool a pile of #ygold from unfortunate adventurers, along with a curious creature who seems to be attracted to the shiny metal.",
-      "You exit the invigorating slime bath, fishing out the #ygold, leaving the creature with a sad look upon its amorphous face.",
-      "You succeed in negotiating a deal with the creature to provide it with more shiny metal if it will aid you in your quest. NL You and your newfound #gfriend exit the slime bath together."
+      "You fall into a puddle. NL @IT'S@ @MADE@ @OF@ #g@SLIME@ #g@GOOP!!@ NL Calmly, you bathe yourself as you bond with the goop, enjoying a moment of reprieve. NL NL Climbing out, you notice in the pool the #ysouls of a few unfortunate adventurers, slowly being consumed by a gluttonous creature.",
+      "You exit the invigorating slime bath, absorbing the #ysouls, leaving the creature with a sad look upon its amorphous face.",
+      "You succeed in negotiating a deal with the creature to provide it with more tasty souls if it will aid you in your quest. NL You and your newfound #gfriend exit the slime bath together."
     ],
     "OPTIONS": [
-      "[Gather Gold] #gGain #g75 #gGold.",
-      "[Recruit] #rLose #r75 #rGold. #gGain #yGreed #yOoze.",
+      "[Gather Souls] #gGain #g75 #gSouls.",
+      "[Recruit] #rLose #r75 #rSouls. #gGain #yGreed #yOoze.",
       "[Leave]",
       "[Locked] Requires 75 Souls."
     ]

--- a/src/main/resources/slimeboundResources/localization/eng/RelicStrings.json
+++ b/src/main/resources/slimeboundResources/localization/eng/RelicStrings.json
@@ -48,9 +48,9 @@
   },
   "Slimebound:GreedOozeRelic": {
     "NAME": "Greed Ooze",
-    "FLAVOR": "A friend found in the Spire who hoards gold.",
+    "FLAVOR": "A friend found in the Spire who devours souls.",
     "DESCRIPTIONS": [
-      "At the start of combat, spawn #yGreed #yOoze. NL At Rest Sites, #yGreed #yOoze will take #b50 of your gold, increasing its damage by #b1."
+      "At the start of combat, spawn #yGreed #yOoze. NL At Rest Sites, #yGreed #yOoze will take #b50 of your souls, increasing its damage by #b1."
     ]
   },
   "Slimebound:PreparedRelic": {


### PR DESCRIPTION
This completes the audit. All events should now list their outcomes in the Run History screen, and no events should cause a crash while loading a saved game due to incomplete metrics.