### PR TITLE
Laser Turret rework: immediate damage and long stasis

### DIFF
--- a/src/main/java/guardian/cards/AbstractGuardianCard.java
+++ b/src/main/java/guardian/cards/AbstractGuardianCard.java
@@ -17,6 +17,7 @@ import com.megacrit.cardcrawl.monsters.AbstractMonster;
 import com.megacrit.cardcrawl.unlock.UnlockTracker;
 import guardian.GuardianMod;
 import guardian.actions.BraceAction;
+import guardian.orbs.StasisOrb;
 import guardian.powers.BeamBuffPower;
 import guardian.powers.ModeShiftPower;
 import guardian.relics.DefensiveModeMoreBlock;
@@ -76,6 +77,10 @@ public abstract class AbstractGuardianCard extends CustomCard {
             }
         }
         return super.getPortraitImage();
+    }
+
+    public void whenEnteredStasis(StasisOrb orb) {
+
     }
 
     public void whenReturnedFromStasis() {

--- a/src/main/java/guardian/cards/GatlingBeam.java
+++ b/src/main/java/guardian/cards/GatlingBeam.java
@@ -26,15 +26,21 @@ public class GatlingBeam extends AbstractGuardianCard implements InStasisCard {
     public static final String NAME;
     public static final String[] EXTENDED_DESCRIPTION;
     public static final String IMG_PATH = "cards/gatlingBeam.png";
-    private static final CardType TYPE = CardType.SKILL;
+    private static final CardType TYPE = CardType.ATTACK;
     private static final CardRarity RARITY = CardRarity.RARE;
-    private static final CardTarget TARGET = CardTarget.SELF;
+    private static final CardTarget TARGET = CardTarget.ENEMY;
     private static final CardStrings cardStrings;
-    private static final int COST = 2;
-    private static final int DAMAGE = 12;
+    private static final int COST = 1;
 
     //TUNING CONSTANTS
-    private static final int UPGRADE_DAMAGE = 4;
+    private static final int DAMAGE = 10;
+    private static final int UPGRADE_DAMAGE = 2;
+
+    private static final int TICK_DURATION = 4;
+    private static final int UPGRADE_TICK_DURATION = 1;
+
+
+
     private static final int SOCKETS = 0;
     private static final boolean SOCKETSAREAFTER = true;
     public static String DESCRIPTION;
@@ -51,17 +57,15 @@ public class GatlingBeam extends AbstractGuardianCard implements InStasisCard {
 
     }
 
-    private int turnsInStasis = 0;
-
     public GatlingBeam() {
 
         super(ID, NAME, GuardianMod.getResourcePath(IMG_PATH), COST, DESCRIPTION, TYPE, AbstractCardEnum.GUARDIAN, RARITY, TARGET);
 
         this.baseDamage = DAMAGE;
+        this.baseMagicNumber = this.magicNumber = TICK_DURATION;
 
         this.tags.add(GuardianMod.BEAM);
         this.tags.add(GuardianMod.TICK);
-        this.tags.add(GuardianMod.VOLATILE);
         this.tags.add(GuardianMod.SELFSTASIS);
         this.socketCount = SOCKETS;
         updateDescription();
@@ -81,6 +85,15 @@ public class GatlingBeam extends AbstractGuardianCard implements InStasisCard {
 
     public void use(AbstractPlayer p, AbstractMonster m) {
         super.use(p, m);
+        AbstractDungeon.actionManager.addToBottom(new SFXAction("ATTACK_MAGIC_BEAM_SHORT", 0.5F));
+        AbstractDungeon.actionManager.addToBottom(new VFXAction(new SmallLaserEffectColored(m.hb.cX, m.hb.cY, AbstractDungeon.player.hb.cX, AbstractDungeon.player.hb.cY, Color.BLUE), 0.1F));
+        AbstractDungeon.actionManager.addToBottom(new DamageAction(m, new com.megacrit.cardcrawl.cards.DamageInfo(p, this.damage, this.damageTypeForTurn), AbstractGameAction.AttackEffect.FIRE));
+
+    }
+
+    @Override
+    public void whenEnteredStasis(StasisOrb orb) {
+        orb.passiveAmount = this.baseMagicNumber;
     }
 
     public AbstractCard makeCopy() {
@@ -95,6 +108,7 @@ public class GatlingBeam extends AbstractGuardianCard implements InStasisCard {
 
             upgradeName();
             upgradeDamage(UPGRADE_DAMAGE);
+            upgradeMagicNumber(UPGRADE_TICK_DURATION);
 
         }
 

--- a/src/main/java/guardian/orbs/StasisOrb.java
+++ b/src/main/java/guardian/orbs/StasisOrb.java
@@ -15,6 +15,7 @@ import com.megacrit.cardcrawl.vfx.AbstractGameEffect;
 import guardian.GuardianMod;
 import guardian.actions.ReturnStasisCardToHandAction;
 import guardian.actions.StasisEvokeIfRoomInHandAction;
+import guardian.cards.AbstractGuardianCard;
 import guardian.cards.InStasisCard;
 import guardian.relics.StasisUpgradeRelic;
 import guardian.vfx.AddCardToStasisEffect;
@@ -79,6 +80,11 @@ public class StasisOrb extends AbstractOrb {
         this.updateDescription();
 
         initialize(source, selfStasis);
+
+        if(stasisCard instanceof AbstractGuardianCard) {
+            AbstractGuardianCard agc = (AbstractGuardianCard) stasisCard;
+            agc.whenEnteredStasis(this);
+        }
     }
 
     @Override
@@ -187,6 +193,7 @@ public class StasisOrb extends AbstractOrb {
 
         AbstractDungeon.effectsQueue.add(stasisStartEffect);
         stasisCard.retain = false;
+
     }
 
     @Override

--- a/src/main/resources/guardianResources/localization/eng/CardStrings.json
+++ b/src/main/resources/guardianResources/localization/eng/CardStrings.json
@@ -373,7 +373,7 @@
   },
   "Guardian:GatlingBeam": {
     "NAME": "Laser Turret",
-    "DESCRIPTION": "Place this into guardianmod:Stasis. NL guardianmod:Tick - Deal !D! damage to a random enemy. NL guardianmod:Volatile."
+    "DESCRIPTION": "Deal !D! damage. NL Place this into guardianmod:Stasis. NL guardianmod:Stasis lasts !M! turns. NL guardianmod:Tick - Deal !D! damage to a random enemy."
   },
   "Guardian:ShieldCharger": {
     "NAME": "Shield Charger",


### PR DESCRIPTION
Remains in stasis for !M! turns regardless of how it got there. Comes out of stasis with 0 cost like any other card in stasis.
![image](https://user-images.githubusercontent.com/307683/158929474-f68e9a2d-c2a7-4f2e-baf1-eab459774985.png)
