### PR TITLE
Implementing cards and relics and fixing issues spotted

### DIFF
--- a/src/main/java/charbosses/actions/vfx/cardmanip/EnemyShowCardAndAddToHandEffect.java
+++ b/src/main/java/charbosses/actions/vfx/cardmanip/EnemyShowCardAndAddToHandEffect.java
@@ -40,7 +40,13 @@ public class EnemyShowCardAndAddToHandEffect extends AbstractGameEffect {
             card.upgrade();
         }
         card.untip();
-        AbstractCharBoss.boss.hand.group.add(0, card);
+        ArrayList<AbstractCard> group = AbstractCharBoss.boss.hand.group;
+        if (card.name.equals("Smite")) {
+            group.add(group.size(), card);
+        }
+        else {
+            group.add(0, card);
+        }
         card.triggerWhenCopied();
         AbstractCharBoss.boss.hand.refreshHandLayout();
         AbstractCharBoss.boss.hand.applyPowers();

--- a/src/main/java/charbosses/cards/AbstractBossCard.java
+++ b/src/main/java/charbosses/cards/AbstractBossCard.java
@@ -311,6 +311,13 @@ public abstract class AbstractBossCard extends AbstractCard {
         if (mo != null) {
             this.damage = MathUtils.floor(calculateDamage(mo, player, this.baseDamage));
             this.intentDmg = MathUtils.floor(manualCustomDamageModifierMult * calculateDamage(mo, player, this.baseDamage + customIntentModifiedDamage() + manualCustomDamageModifier));
+            if (this instanceof EnCarveReality) {
+                if (((EnCarveReality)this).willUseSmite) {
+                    EnSmite enSmite = new EnSmite();
+                    enSmite.calculateCardDamage(this.owner);
+                    this.intentDmg += enSmite.intentDmg;
+                }
+            }
         }
         this.initializeDescription();
     }

--- a/src/main/java/charbosses/cards/blue/EnFusion.java
+++ b/src/main/java/charbosses/cards/blue/EnFusion.java
@@ -1,0 +1,61 @@
+package charbosses.cards.blue;
+
+import charbosses.actions.orb.EnemyChannelAction;
+import charbosses.bosses.AbstractCharBoss;
+import charbosses.cards.AbstractBossCard;
+import charbosses.orbs.AbstractEnemyOrb;
+import charbosses.orbs.EnemyLightning;
+import charbosses.orbs.EnemyPlasma;
+import com.megacrit.cardcrawl.cards.AbstractCard;
+import com.megacrit.cardcrawl.characters.AbstractPlayer;
+import com.megacrit.cardcrawl.core.CardCrawlGame;
+import com.megacrit.cardcrawl.localization.CardStrings;
+import com.megacrit.cardcrawl.monsters.AbstractMonster;
+import com.megacrit.cardcrawl.powers.FocusPower;
+
+import java.util.ArrayList;
+
+public class EnFusion extends AbstractBossCard {
+    public static final String ID = "downfall_Charboss:Fusion";
+    private static final CardStrings cardStrings;
+
+    static {
+        cardStrings = CardCrawlGame.languagePack.getCardStrings("Fusion");
+    }
+    public EnFusion(boolean upgraded) {
+        this();
+        if (upgraded)
+            upgrade();
+    }
+
+    public EnFusion() {
+        super(ID, cardStrings.NAME, "blue/skill/fusion", 2, cardStrings.DESCRIPTION, CardType.SKILL, CardColor.BLUE, CardRarity.BASIC, CardTarget.SELF, AbstractMonster.Intent.BUFF);
+        this.showEvokeValue = true;
+        this.showEvokeOrbCount = 1;
+        this.baseMagicNumber = 1;
+        this.magicNumber = this.baseMagicNumber;
+        alwaysDisplayText = true;
+    }
+
+    public void use(AbstractPlayer p, AbstractMonster m) {
+        for (int i = 0; i < this.magicNumber; ++i) {
+            this.addToBot(new EnemyChannelAction(new EnemyPlasma()));
+        }
+    }
+
+    @Override
+    public int getPriority(ArrayList<AbstractCard> hand) {
+        return 10;
+    }
+
+    public void upgrade() {
+        if (!this.upgraded) {
+            this.upgradeName();
+            this.upgradeBaseCost(1);
+        }
+    }
+
+    public AbstractCard makeCopy() {
+        return new EnFusion();
+    }
+}

--- a/src/main/java/charbosses/cards/blue/EnReinforcedBody.java
+++ b/src/main/java/charbosses/cards/blue/EnReinforcedBody.java
@@ -1,10 +1,14 @@
 package charbosses.cards.blue;
 
+import charbosses.actions.common.EnemyGainEnergyAction;
 import charbosses.actions.orb.EnemyAnimateOrbAction;
 import charbosses.actions.orb.EnemyEvokeOrbAction;
 import charbosses.actions.orb.EnemyEvokeWithoutRemovingOrbAction;
 import charbosses.cards.AbstractBossCard;
+import charbosses.ui.EnemyEnergyPanel;
 import com.megacrit.cardcrawl.actions.common.GainBlockAction;
+import com.megacrit.cardcrawl.actions.common.GainEnergyAction;
+import com.megacrit.cardcrawl.actions.unique.LoseEnergyAction;
 import com.megacrit.cardcrawl.cards.AbstractCard;
 import com.megacrit.cardcrawl.characters.AbstractPlayer;
 import com.megacrit.cardcrawl.core.CardCrawlGame;
@@ -25,16 +29,20 @@ public class EnReinforcedBody extends AbstractBossCard {
     }
 
     public EnReinforcedBody(int inCost) {
-        super(ID, cardStrings.NAME, "blue/skill/reinforced_body", inCost, cardStrings.DESCRIPTION, CardType.SKILL, CardColor.BLUE, CardRarity.UNCOMMON, CardTarget.NONE, AbstractMonster.Intent.BUFF);
+        super(ID, cardStrings.NAME, "blue/skill/reinforced_body", inCost, cardStrings.DESCRIPTION, CardType.SKILL, CardColor.BLUE, CardRarity.UNCOMMON, CardTarget.NONE, AbstractMonster.Intent.DEFEND);
         this.baseBlock = 7;
         cost = inCost;
     }
 
 
     public void use(AbstractPlayer p, AbstractMonster m) {
-        for (int i = 0; i < cost; i++) {
+        int realCost = this.owner.energyPanel.getCurrentEnergy();
+        for (int i = 0; i < realCost; i++) {
             this.addToBot(new GainBlockAction(m, m, this.block));
         }
+        // TODO: ew
+        EnemyEnergyPanel.useEnergy(realCost - cost);
+        this.owner.hand.glowCheck();
     }
 
     public void upgrade() {

--- a/src/main/java/charbosses/cards/green/EnPhantasmalKiller.java
+++ b/src/main/java/charbosses/cards/green/EnPhantasmalKiller.java
@@ -1,0 +1,52 @@
+package charbosses.cards.green;
+
+import charbosses.cards.AbstractBossCard;
+import charbosses.powers.cardpowers.EnemyNoxiousFumesPower;
+import charbosses.powers.cardpowers.EnemyPhantasmalPower;
+import com.megacrit.cardcrawl.actions.common.ApplyPowerAction;
+import com.megacrit.cardcrawl.cards.AbstractCard;
+import com.megacrit.cardcrawl.cards.green.NoxiousFumes;
+import com.megacrit.cardcrawl.cards.green.PhantasmalKiller;
+import com.megacrit.cardcrawl.characters.AbstractPlayer;
+import com.megacrit.cardcrawl.core.CardCrawlGame;
+import com.megacrit.cardcrawl.localization.CardStrings;
+import com.megacrit.cardcrawl.monsters.AbstractMonster;
+
+import java.util.ArrayList;
+
+public class EnPhantasmalKiller extends AbstractBossCard {
+    public static final String ID = "downfall_Charboss:Phantasmal Killer";
+    private static final CardStrings cardStrings;
+
+    static {
+        cardStrings = CardCrawlGame.languagePack.getCardStrings(PhantasmalKiller.ID);
+    }
+
+    public EnPhantasmalKiller() {
+        super(ID, EnPhantasmalKiller.cardStrings.NAME, "green/power/phantasmal_killer", 1, EnPhantasmalKiller.cardStrings.DESCRIPTION, CardType.POWER, CardColor.GREEN, CardRarity.UNCOMMON, CardTarget.SELF, AbstractMonster.Intent.BUFF);
+        baseMagicNumber = magicNumber = 1;
+    }
+
+    @Override
+    public void use(final AbstractPlayer p, final AbstractMonster m) {
+        this.addToBot(new ApplyPowerAction(m, m, new EnemyPhantasmalPower(m, magicNumber), magicNumber));
+    }
+
+    @Override
+    public int getPriority(ArrayList<AbstractCard> hand) {
+        return 15;
+    }
+
+    @Override
+    public void upgrade() {
+        if (!this.upgraded) {
+            this.upgradeName();
+            upgradeMagicNumber(1);
+        }
+    }
+
+    @Override
+    public AbstractCard makeCopy() {
+        return new EnPhantasmalKiller();
+    }
+}

--- a/src/main/java/charbosses/cards/green/EnSkewer.java
+++ b/src/main/java/charbosses/cards/green/EnSkewer.java
@@ -1,0 +1,61 @@
+package charbosses.cards.green;
+
+import charbosses.actions.common.EnemyModifyDamageAction;
+import charbosses.cards.AbstractBossCard;
+import com.megacrit.cardcrawl.actions.AbstractGameAction;
+import com.megacrit.cardcrawl.actions.common.DamageAction;
+import com.megacrit.cardcrawl.actions.unique.SkewerAction;
+import com.megacrit.cardcrawl.cards.AbstractCard;
+import com.megacrit.cardcrawl.cards.DamageInfo;
+import com.megacrit.cardcrawl.characters.AbstractPlayer;
+import com.megacrit.cardcrawl.core.CardCrawlGame;
+import com.megacrit.cardcrawl.localization.CardStrings;
+import com.megacrit.cardcrawl.monsters.AbstractMonster;
+
+import java.util.ArrayList;
+
+public class EnSkewer extends AbstractBossCard {
+    public static final String ID = "downfall_Charboss:Skewer";
+    private static final CardStrings cardStrings;
+    private int cost;
+
+    static {
+        cardStrings = CardCrawlGame.languagePack.getCardStrings("Skewer");
+    }
+
+    public EnSkewer(int cost) {
+        super(ID, EnSkewer.cardStrings.NAME, "green/attack/skewer", cost, EnSkewer.cardStrings.DESCRIPTION, CardType.ATTACK, CardColor.GREEN, CardRarity.RARE, CardTarget.ENEMY, AbstractMonster.Intent.ATTACK);
+        this.baseDamage = 7;
+        this.baseMagicNumber = cost;
+        this.magicNumber = this.baseMagicNumber;
+        this.isMultiDamage = true;
+        intentMultiAmt = 2;
+        this.cost = cost;
+    }
+
+
+    @Override
+    public void use(final AbstractPlayer p, final AbstractMonster m) {
+        for (int i = 0; i < cost; ++i) {
+            this.addToBot(new DamageAction(p, new DamageInfo(m, this.damage, this.damageTypeForTurn), AbstractGameAction.AttackEffect.SLASH_HORIZONTAL));
+        }
+    }
+
+    @Override
+    public int getPriority(ArrayList<AbstractCard> hand) {
+        return autoPriority() * 2;
+    }
+
+    @Override
+    public void upgrade() {
+        if (!this.upgraded) {
+            this.upgradeName();
+            this.upgradeDamage(3);
+        }
+    }
+
+    @Override
+    public AbstractCard makeCopy() {
+        return new EnSkewer(3);
+    }
+}

--- a/src/main/java/charbosses/cards/purple/EnCarveReality.java
+++ b/src/main/java/charbosses/cards/purple/EnCarveReality.java
@@ -16,14 +16,16 @@ import com.megacrit.cardcrawl.monsters.AbstractMonster;
 public class EnCarveReality extends AbstractBossCard {
     public static final String ID = "downfall_Charboss:CarveReality";
     private static final CardStrings cardStrings;
+    public boolean willUseSmite;
 
     static {
         cardStrings = CardCrawlGame.languagePack.getCardStrings("CarveReality");
     }
 
-    public EnCarveReality() {
+    public EnCarveReality(boolean willUseSmite) {
         super(ID, cardStrings.NAME, "purple/attack/carve_reality", 1, cardStrings.DESCRIPTION, CardType.ATTACK, CardColor.PURPLE, CardRarity.UNCOMMON, CardTarget.ENEMY, AbstractMonster.Intent.ATTACK);
         this.baseDamage = 6;
+        this.willUseSmite = willUseSmite;
         this.cardsToPreview = new EnSmite();
     }
 
@@ -31,6 +33,16 @@ public class EnCarveReality extends AbstractBossCard {
     public void use(final AbstractPlayer p, final AbstractMonster m) {
         this.addToBot(new DamageAction(p, new DamageInfo(m, this.damage, this.damageTypeForTurn), AbstractGameAction.AttackEffect.SLASH_HEAVY));
         this.addToBot(new EnemyMakeTempCardInHandAction(new EnSmite(), 1));
+    }
+
+    @Override
+    public int customIntentModifiedDamage() {
+        int extraDamage = 0;
+
+        if (owner.hasPower(EnemyMasterRealityPower.POWER_ID)){
+            extraDamage = 6;
+        }
+        return extraDamage;
     }
 
     @Override
@@ -43,6 +55,6 @@ public class EnCarveReality extends AbstractBossCard {
 
     @Override
     public AbstractCard makeCopy() {
-        return new EnCarveReality();
+        return new EnCarveReality(willUseSmite);
     }
 }

--- a/src/main/java/charbosses/cards/purple/EnLessonLearned.java
+++ b/src/main/java/charbosses/cards/purple/EnLessonLearned.java
@@ -1,0 +1,42 @@
+package charbosses.cards.purple;
+
+import charbosses.cards.AbstractBossCard;
+import com.megacrit.cardcrawl.actions.AbstractGameAction;
+import com.megacrit.cardcrawl.actions.common.DamageAction;
+import com.megacrit.cardcrawl.cards.AbstractCard;
+import com.megacrit.cardcrawl.cards.DamageInfo;
+import com.megacrit.cardcrawl.characters.AbstractPlayer;
+import com.megacrit.cardcrawl.core.CardCrawlGame;
+import com.megacrit.cardcrawl.localization.CardStrings;
+import com.megacrit.cardcrawl.monsters.AbstractMonster;
+
+public class EnLessonLearned extends AbstractBossCard {
+    public static final String ID = "downfall_Charboss:LessonLearned";
+    private static final CardStrings cardStrings;
+
+    public EnLessonLearned() {
+        super(ID, cardStrings.NAME, "colorless/attack/lessons_learned", 2, cardStrings.DESCRIPTION, CardType.ATTACK, CardColor.PURPLE, CardRarity.RARE, CardTarget.ENEMY, AbstractMonster.Intent.ATTACK);
+        this.baseDamage = 10;
+        this.exhaust = true;
+    }
+
+    public void use(AbstractPlayer p, AbstractMonster m) {
+        this.addToBot(new DamageAction(p, new DamageInfo(m, this.damage, this.damageTypeForTurn), AbstractGameAction.AttackEffect.BLUNT_HEAVY));
+    }
+
+    public AbstractCard makeCopy() {
+        return new EnLessonLearned();
+    }
+
+    public void upgrade() {
+        if (!this.upgraded) {
+            this.upgradeName();
+            this.upgradeDamage(3);
+        }
+
+    }
+
+    static {
+        cardStrings = CardCrawlGame.languagePack.getCardStrings("LessonLearned");
+    }
+}

--- a/src/main/java/charbosses/cards/purple/EnMasterReality.java
+++ b/src/main/java/charbosses/cards/purple/EnMasterReality.java
@@ -1,0 +1,57 @@
+package charbosses.cards.purple;
+
+import charbosses.cards.AbstractBossCard;
+import charbosses.powers.cardpowers.EnemyDevotionPower;
+import charbosses.powers.cardpowers.EnemyMasterRealityPower;
+import com.megacrit.cardcrawl.actions.animations.VFXAction;
+import com.megacrit.cardcrawl.actions.common.ApplyPowerAction;
+import com.megacrit.cardcrawl.actions.utility.SFXAction;
+import com.megacrit.cardcrawl.cards.AbstractCard;
+import com.megacrit.cardcrawl.characters.AbstractPlayer;
+import com.megacrit.cardcrawl.core.CardCrawlGame;
+import com.megacrit.cardcrawl.core.Settings;
+import com.megacrit.cardcrawl.helpers.GameDictionary;
+import com.megacrit.cardcrawl.localization.CardStrings;
+import com.megacrit.cardcrawl.monsters.AbstractMonster;
+import com.megacrit.cardcrawl.vfx.combat.DevotionEffect;
+
+import java.util.ArrayList;
+
+public class EnMasterReality extends AbstractBossCard {
+    public static final String ID = "downfall_Charboss:Devotion";
+    private static final CardStrings cardStrings;
+
+    public EnMasterReality() {
+        super(ID, cardStrings.NAME, "purple/power/master_reality", 1, cardStrings.DESCRIPTION, CardType.POWER, CardColor.PURPLE, CardRarity.RARE, CardTarget.NONE, AbstractMonster.Intent.BUFF);
+    }
+
+    public void use(AbstractPlayer p, AbstractMonster m) {
+        this.addToBot(new ApplyPowerAction(m, m, new EnemyMasterRealityPower(m)));
+    }
+
+    public AbstractCard makeCopy() {
+        return new EnMasterReality();
+    }
+
+    public void initializeDescription() {
+        super.initializeDescription();
+        this.keywords.add(GameDictionary.ENLIGHTENMENT.NAMES[0].toLowerCase());
+    }
+
+    public void upgrade() {
+        if (!this.upgraded) {
+            this.upgradeName();
+            this.upgradeMagicNumber(1);
+        }
+
+    }
+
+    @Override
+    public int getPriority(ArrayList<AbstractCard> hand) {
+        return 100;
+    }
+
+    static {
+        cardStrings = CardCrawlGame.languagePack.getCardStrings("MasterReality");
+    }
+}

--- a/src/main/java/charbosses/cards/purple/EnMeditate.java
+++ b/src/main/java/charbosses/cards/purple/EnMeditate.java
@@ -4,7 +4,6 @@ import charbosses.actions.unique.EnemyChangeStanceAction;
 import charbosses.bosses.AbstractCharBoss;
 import charbosses.cards.AbstractBossCard;
 import charbosses.stances.EnCalmStance;
-import com.megacrit.cardcrawl.actions.common.GainBlockAction;
 import com.megacrit.cardcrawl.cards.AbstractCard;
 import com.megacrit.cardcrawl.characters.AbstractPlayer;
 import com.megacrit.cardcrawl.core.CardCrawlGame;
@@ -13,13 +12,14 @@ import com.megacrit.cardcrawl.monsters.AbstractMonster;
 
 import java.util.ArrayList;
 
-public class EnTranquility extends AbstractBossCard {
-    public static final String ID = "downfall_Charboss:ClearTheMind";
+public class EnMeditate extends AbstractBossCard {
+    public static final String ID = "downfall_Charboss:Meditate";
     private static final CardStrings cardStrings;
 
-    public EnTranquility() {
-        super(ID, cardStrings.NAME, "purple/skill/tranquility", 1, cardStrings.DESCRIPTION, CardType.SKILL, CardColor.PURPLE, CardRarity.COMMON, CardTarget.SELF, AbstractMonster.Intent.BUFF);
-        this.exhaust = true;
+    public EnMeditate() {
+        super(ID, cardStrings.NAME, "purple/skill/meditate", 1, cardStrings.DESCRIPTION, CardType.SKILL, CardColor.PURPLE, CardRarity.UNCOMMON, CardTarget.SELF, AbstractMonster.Intent.BUFF);
+        this.baseBlock = 8;
+        this.block = this.baseBlock;
     }
 
     public void use(AbstractPlayer p, AbstractMonster m) {
@@ -33,18 +33,13 @@ public class EnTranquility extends AbstractBossCard {
     }
 
     public void upgrade() {
-        if (!this.upgraded) {
-            this.upgradeName();
-            this.upgradeBaseCost(0);
-        }
-
     }
 
     public AbstractCard makeCopy() {
-        return new EnTranquility();
+        return new EnMeditate();
     }
 
     static {
-        cardStrings = CardCrawlGame.languagePack.getCardStrings("ClearTheMind");
+        cardStrings = CardCrawlGame.languagePack.getCardStrings("Meditate");
     }
 }

--- a/src/main/java/charbosses/cards/red/EnSpotWeakness.java
+++ b/src/main/java/charbosses/cards/red/EnSpotWeakness.java
@@ -1,0 +1,62 @@
+package charbosses.cards.red;
+
+import charbosses.bosses.AbstractCharBoss;
+import charbosses.cards.AbstractBossCard;
+import charbosses.powers.cardpowers.EnemySpotWeaknessPower;
+import com.megacrit.cardcrawl.actions.common.ApplyPowerAction;
+import com.megacrit.cardcrawl.actions.common.GainBlockAction;
+import com.megacrit.cardcrawl.actions.utility.UseCardAction;
+import com.megacrit.cardcrawl.cards.AbstractCard;
+import com.megacrit.cardcrawl.characters.AbstractPlayer;
+import com.megacrit.cardcrawl.core.CardCrawlGame;
+import com.megacrit.cardcrawl.core.Settings;
+import com.megacrit.cardcrawl.localization.CardStrings;
+import com.megacrit.cardcrawl.monsters.AbstractMonster;
+import com.megacrit.cardcrawl.powers.AbstractPower;
+import com.megacrit.cardcrawl.powers.LoseStrengthPower;
+import com.megacrit.cardcrawl.powers.StrengthPower;
+
+import java.util.ArrayList;
+
+public class EnSpotWeakness extends AbstractBossCard {
+    public static final String ID = "downfall_Charboss:SpotWeakness";
+    private static final CardStrings cardStrings;
+
+    static {
+        cardStrings = CardCrawlGame.languagePack.getCardStrings("Spot Weakness");
+    }
+
+    public EnSpotWeakness() {
+        super(ID, EnSpotWeakness.cardStrings.NAME, "red/skill/spot_weakness", 1, EnSpotWeakness.cardStrings.DESCRIPTION, CardType.SKILL, CardColor.RED, CardRarity.UNCOMMON, CardTarget.SELF, AbstractMonster.Intent.BUFF);
+        this.baseMagicNumber = 3;
+        this.magicNumber = this.baseMagicNumber;
+    }
+
+    @Override
+    public void use(final AbstractPlayer p, final AbstractMonster m) {
+//        this.addToBot(new ApplyPowerAction(m, m, new StrengthPower(m, this.magicNumber), this.magicNumber));
+        if (m.hasPower(EnemySpotWeaknessPower.POWER_ID)) {
+            EnemySpotWeaknessPower power = (EnemySpotWeaknessPower) m.getPower(EnemySpotWeaknessPower.POWER_ID);
+            this.addToBot(new ApplyPowerAction(m, m, new StrengthPower(m, power.amount), power.amount));
+        }
+    }
+
+    @Override
+    public int getPriority(ArrayList<AbstractCard> hand) {
+        return super.getPriority(hand) + 10;
+    }
+
+
+    @Override
+    public void upgrade() {
+        if (!this.upgraded) {
+            this.upgradeName();
+            this.upgradeMagicNumber(1);
+        }
+    }
+
+    @Override
+    public AbstractCard makeCopy() {
+        return new EnSpotWeakness();
+    }
+}

--- a/src/main/java/charbosses/cards/red/EnSwordBoomerang.java
+++ b/src/main/java/charbosses/cards/red/EnSwordBoomerang.java
@@ -26,6 +26,7 @@ public class EnSwordBoomerang extends AbstractBossCard {
         this.baseDamage = 3;
         this.baseMagicNumber = 3;
         this.magicNumber = this.baseMagicNumber;
+        this.isMultiDamage = true;
         this.tags.add(downfallMod.CHARBOSS_ATTACK);
     }
 

--- a/src/main/java/charbosses/orbs/AbstractEnemyOrb.java
+++ b/src/main/java/charbosses/orbs/AbstractEnemyOrb.java
@@ -86,6 +86,9 @@ public abstract class AbstractEnemyOrb extends AbstractOrb {
     }
 
     public void applyFocus() {
+        if (this instanceof EnemyPlasma) {
+            return;
+        }
         if (AbstractCharBoss.boss.hasPower(FocusPower.POWER_ID)) {
             AbstractPower power = AbstractCharBoss.boss.getPower(FocusPower.POWER_ID);
             this.passiveAmount = Math.max(0, this.basePassiveAmount + power.amount + pretendFocus);

--- a/src/main/java/charbosses/orbs/EnemyPlasma.java
+++ b/src/main/java/charbosses/orbs/EnemyPlasma.java
@@ -61,7 +61,7 @@ public class EnemyPlasma extends AbstractEnemyOrb {
     }
 
     @Override
-    public void onStartOfTurn() {
+    public void onEndOfTurn() {
         AbstractDungeon.actionManager.addToTop(new VFXAction(new OrbFlareEffect(this, OrbFlareEffect.OrbFlareColor.PLASMA), 0.1f));
         AbstractDungeon.actionManager.addToTop(new EnemyGainEnergyAction(this.passiveAmount));
     }

--- a/src/main/java/charbosses/powers/cardpowers/EnemyDevaFormPower.java
+++ b/src/main/java/charbosses/powers/cardpowers/EnemyDevaFormPower.java
@@ -35,7 +35,7 @@ public class EnemyDevaFormPower extends AbstractPower {
         if (this.energyGainAmount == 1) {
             this.description = DESCRIPTIONS[0] + DESCRIPTIONS[3] + this.amount + DESCRIPTIONS[4];
         } else {
-            this.description = DESCRIPTIONS[1] + this.energyGainAmount + DESCRIPTIONS[2] + DESCRIPTIONS[3] + this.amount + DESCRIPTIONS[4];
+            this.description = DESCRIPTIONS[1] + (this.energyGainAmount - 1) + DESCRIPTIONS[2] + DESCRIPTIONS[3] + this.amount + DESCRIPTIONS[4];
         }
 
     }

--- a/src/main/java/charbosses/powers/cardpowers/EnemyMasterRealityPower.java
+++ b/src/main/java/charbosses/powers/cardpowers/EnemyMasterRealityPower.java
@@ -1,0 +1,32 @@
+package charbosses.powers.cardpowers;
+
+
+import charbosses.bosses.AbstractCharBoss;
+import charbosses.stances.EnCalmStance;
+import com.megacrit.cardcrawl.actions.common.GainBlockAction;
+import com.megacrit.cardcrawl.core.AbstractCreature;
+import com.megacrit.cardcrawl.core.CardCrawlGame;
+import com.megacrit.cardcrawl.localization.PowerStrings;
+import com.megacrit.cardcrawl.powers.AbstractPower;
+
+public class EnemyMasterRealityPower extends AbstractPower {
+    public static final String POWER_ID = "MasterRealityPower";
+    private static final PowerStrings powerStrings;
+
+    public EnemyMasterRealityPower(AbstractCreature owner) {
+        this.name = powerStrings.NAME;
+        this.ID = "MasterRealityPower";
+        this.owner = owner;
+        this.updateDescription();
+        this.loadRegion("master_reality");
+        this.type = PowerType.BUFF;
+    }
+
+    public void updateDescription() {
+        this.description = powerStrings.DESCRIPTIONS[0] + this.amount + powerStrings.DESCRIPTIONS[1];
+    }
+
+    static {
+        powerStrings = CardCrawlGame.languagePack.getPowerStrings("MasterRealityPower");
+    }
+}

--- a/src/main/java/charbosses/powers/cardpowers/EnemyPhantasmalPower.java
+++ b/src/main/java/charbosses/powers/cardpowers/EnemyPhantasmalPower.java
@@ -1,0 +1,43 @@
+package charbosses.powers.cardpowers;
+
+import charbosses.powers.general.EnemyPoisonPower;
+import com.megacrit.cardcrawl.actions.common.ApplyPowerAction;
+import com.megacrit.cardcrawl.actions.common.ReducePowerAction;
+import com.megacrit.cardcrawl.core.AbstractCreature;
+import com.megacrit.cardcrawl.core.CardCrawlGame;
+import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
+import com.megacrit.cardcrawl.localization.PowerStrings;
+import com.megacrit.cardcrawl.powers.AbstractPower;
+import com.megacrit.cardcrawl.powers.DoubleDamagePower;
+import com.megacrit.cardcrawl.powers.NoxiousFumesPower;
+import com.megacrit.cardcrawl.powers.PhantasmalPower;
+
+public class EnemyPhantasmalPower extends AbstractPower {
+    public static final String POWER_ID = "downfall:Phantasmal";
+    private static final PowerStrings powerStrings;
+
+    static {
+        powerStrings = CardCrawlGame.languagePack.getPowerStrings(PhantasmalPower.POWER_ID);
+    }
+
+    public EnemyPhantasmalPower(final AbstractCreature owner, final int amount) {
+        this.name = EnemyPhantasmalPower.powerStrings.NAME;
+        this.ID = "Phantasmal";
+        this.owner = owner;
+        this.amount = amount;
+        this.updateDescription();
+        this.loadRegion("phantasmal");
+    }
+
+    @Override
+    public void atEndOfTurn(boolean isPlayer) {
+        this.flash();
+        this.addToBot(new ApplyPowerAction(this.owner, this.owner, new DoubleDamagePower(this.owner, 1, true), this.amount));
+        this.addToBot(new ReducePowerAction(this.owner, this.owner, "Phantasmal", 1));
+    }
+
+    @Override
+    public void updateDescription() {
+        this.description = EnemyPhantasmalPower.powerStrings.DESCRIPTIONS[0] + this.amount + EnemyPhantasmalPower.powerStrings.DESCRIPTIONS[1];
+    }
+}

--- a/src/main/java/charbosses/powers/cardpowers/EnemySpotWeaknessPower.java
+++ b/src/main/java/charbosses/powers/cardpowers/EnemySpotWeaknessPower.java
@@ -1,0 +1,83 @@
+package charbosses.powers.cardpowers;
+import charbosses.bosses.AbstractCharBoss;
+import charbosses.cards.AbstractBossCard;
+import com.megacrit.cardcrawl.actions.AbstractGameAction.AttackEffect;
+import com.megacrit.cardcrawl.actions.common.ApplyPowerAction;
+import com.megacrit.cardcrawl.actions.common.DamageAction;
+import com.megacrit.cardcrawl.actions.common.GainBlockAction;
+import com.megacrit.cardcrawl.actions.common.RemoveSpecificPowerAction;
+import com.megacrit.cardcrawl.actions.utility.UseCardAction;
+import com.megacrit.cardcrawl.cards.AbstractCard;
+import com.megacrit.cardcrawl.cards.DamageInfo;
+import com.megacrit.cardcrawl.cards.DamageInfo.DamageType;
+import com.megacrit.cardcrawl.core.AbstractCreature;
+import com.megacrit.cardcrawl.core.CardCrawlGame;
+import com.megacrit.cardcrawl.core.Settings;
+import com.megacrit.cardcrawl.localization.PowerStrings;
+import com.megacrit.cardcrawl.powers.AbstractPower;
+import com.megacrit.cardcrawl.powers.GainStrengthPower;
+import com.megacrit.cardcrawl.powers.StrengthPower;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public class EnemySpotWeaknessPower extends AbstractPower {
+    private static final Logger logger = LogManager.getLogger(com.megacrit.cardcrawl.powers.FlameBarrierPower.class.getName());
+    public static final String POWER_ID = "Spot Weakness";
+    private static final PowerStrings powerStrings;
+    public static final String NAME;
+    public static final String[] DESCRIPTIONS;
+    public boolean isActive;
+    public int theoreticalGain;
+
+    public EnemySpotWeaknessPower(AbstractCreature owner, int strengthGain) {
+        this.name = NAME;
+        this.ID = "Spot Weakness";
+        this.owner = owner;
+        this.amount = 0;
+        this.theoreticalGain = strengthGain;
+        this.updateDescription();
+        this.loadRegion("curiosity");
+        isActive = false;
+    }
+
+    public void stackPower(int stackAmount) {
+        if (this.amount == -1) {
+            logger.info(this.name + " does not stack");
+        } else {
+            this.fontScale = 8.0F;
+            this.amount += stackAmount;
+            this.updateDescription();
+        }
+    }
+
+    @Override
+    public void onUseCard(final AbstractCard card, final UseCardAction action) {
+        if (card instanceof AbstractBossCard) {
+            return;
+        }
+        if (card.type.equals(AbstractCard.CardType.ATTACK) && !isActive) {
+            this.flash();
+            isActive = true;
+            amount = theoreticalGain;
+            updateDescription();
+        }
+    }
+
+    public void atStartOfTurn() {
+        if (isActive) {
+            this.addToBot(new ApplyPowerAction(AbstractCharBoss.boss, AbstractCharBoss.boss, new StrengthPower(AbstractCharBoss.boss, this.amount)));
+            isActive = false;
+        }
+        this.addToBot(new RemoveSpecificPowerAction(this.owner, this.owner, "Spot Weakness"));
+    }
+
+    public void updateDescription() {
+        this.description = DESCRIPTIONS[0] + this.theoreticalGain + DESCRIPTIONS[1] + this.amount + DESCRIPTIONS[2];
+    }
+
+    static {
+        powerStrings = CardCrawlGame.languagePack.getPowerStrings("downfall:SpotWeakness");
+        NAME = powerStrings.NAME;
+        DESCRIPTIONS = powerStrings.DESCRIPTIONS;
+    }
+}

--- a/src/main/java/charbosses/powers/cardpowers/EnemyVigorPower.java
+++ b/src/main/java/charbosses/powers/cardpowers/EnemyVigorPower.java
@@ -1,6 +1,7 @@
 package charbosses.powers.cardpowers;
 
 import charbosses.bosses.AbstractCharBoss;
+import charbosses.cards.AbstractBossCard;
 import charbosses.relics.AbstractCharbossRelic;
 import charbosses.relics.CBR_Akabeko;
 import com.megacrit.cardcrawl.actions.common.RelicAboveCreatureAction;
@@ -39,7 +40,7 @@ public class EnemyVigorPower extends AbstractPower {
     }
 
     public void onUseCard(AbstractCard card, UseCardAction action) {
-        if (card.type == CardType.ATTACK) {
+        if (card.type == CardType.ATTACK && card instanceof AbstractBossCard) {
             this.flash();
             AbstractCharBoss cB = (AbstractCharBoss)this.owner;
             if (cB.hasRelic(CBR_Akabeko.ID)){

--- a/src/main/java/charbosses/relics/CBR_Duality.java
+++ b/src/main/java/charbosses/relics/CBR_Duality.java
@@ -1,0 +1,45 @@
+package charbosses.relics;
+
+import charbosses.bosses.AbstractCharBoss;
+import com.megacrit.cardcrawl.actions.common.ApplyPowerAction;
+import com.megacrit.cardcrawl.actions.common.RelicAboveCreatureAction;
+import com.megacrit.cardcrawl.actions.unique.RemoveDebuffsAction;
+import com.megacrit.cardcrawl.actions.utility.UseCardAction;
+import com.megacrit.cardcrawl.cards.AbstractCard;
+import com.megacrit.cardcrawl.characters.AbstractPlayer;
+import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
+import com.megacrit.cardcrawl.powers.DexterityPower;
+import com.megacrit.cardcrawl.powers.LoseDexterityPower;
+import com.megacrit.cardcrawl.relics.AbstractRelic;
+import com.megacrit.cardcrawl.relics.Duality;
+import com.megacrit.cardcrawl.relics.OrangePellets;
+
+public class CBR_Duality extends AbstractCharbossRelic {
+    public static final String ID = "Duality";
+
+    public CBR_Duality() {
+        super(new Duality());
+    }
+
+    public String getUpdatedDescription() {
+        return this.DESCRIPTIONS[0];
+    }
+
+    public void onUseCard(AbstractCard card, UseCardAction action) {
+        if (card.type == AbstractCard.CardType.ATTACK) {
+            this.flash();
+            AbstractCharBoss p = this.owner;
+            this.addToBot(new RelicAboveCreatureAction(p, this));
+            this.addToBot(new ApplyPowerAction(p, p, new DexterityPower(p, 1), 1));
+            this.addToBot(new ApplyPowerAction(p, p, new LoseDexterityPower(p, 1), 1));
+        }
+
+
+    }
+
+
+    @Override
+    public AbstractRelic makeCopy() {
+        return new CBR_Duality();
+    }
+}

--- a/src/main/java/charbosses/relics/CBR_Inserter.java
+++ b/src/main/java/charbosses/relics/CBR_Inserter.java
@@ -42,6 +42,6 @@ public class CBR_Inserter extends AbstractCharbossRelic {
     }
 
     public AbstractRelic makeCopy() {
-        return new Inserter();
+        return new CBR_Inserter();
     }
 }

--- a/src/main/java/charbosses/relics/CBR_RunicCapacitor.java
+++ b/src/main/java/charbosses/relics/CBR_RunicCapacitor.java
@@ -1,0 +1,31 @@
+package charbosses.relics;
+
+import charbosses.actions.orb.EnemyIncreaseMaxOrbAction;
+import com.megacrit.cardcrawl.actions.common.ApplyPowerAction;
+import com.megacrit.cardcrawl.actions.common.RelicAboveCreatureAction;
+import com.megacrit.cardcrawl.powers.PlatedArmorPower;
+import com.megacrit.cardcrawl.relics.AbstractRelic;
+import com.megacrit.cardcrawl.relics.Inserter;
+import com.megacrit.cardcrawl.relics.RunicCapacitor;
+
+public class CBR_RunicCapacitor extends AbstractCharbossRelic {
+    public static final String ID = "Runic Capacitor";
+
+    public CBR_RunicCapacitor() {
+        super(new RunicCapacitor());
+    }
+
+    public String getUpdatedDescription() {
+        return this.DESCRIPTIONS[0];
+    }
+
+    public void atBattleStart() {
+        this.flash();
+        this.addToBot(new RelicAboveCreatureAction(this.owner, this));
+        this.addToBot(new EnemyIncreaseMaxOrbAction(3));
+    }
+
+    public AbstractRelic makeCopy() {
+        return new CBR_RunicCapacitor();
+    }
+}

--- a/src/main/java/charbosses/relics/CBR_Sozu.java
+++ b/src/main/java/charbosses/relics/CBR_Sozu.java
@@ -1,0 +1,31 @@
+package charbosses.relics;
+
+import charbosses.bosses.AbstractCharBoss;
+import com.megacrit.cardcrawl.core.EnergyManager;
+import com.megacrit.cardcrawl.relics.AbstractRelic;
+import com.megacrit.cardcrawl.relics.FusionHammer;
+import com.megacrit.cardcrawl.relics.Sozu;
+
+public class CBR_Sozu extends AbstractCharbossRelic {
+    public static final String ID = "Sozu";
+
+    public CBR_Sozu() {
+        super(new Sozu());
+    }
+
+    @Override
+    public void onEquip() {
+        final EnergyManager energy = AbstractCharBoss.boss.energy;
+        ++energy.energyMaster;
+
+    }
+
+    public String getUpdatedDescription() {
+        return this.DESCRIPTIONS[1] + this.DESCRIPTIONS[0];
+    }
+
+    @Override
+    public AbstractRelic makeCopy() {
+        return new CBR_Sozu();
+    }
+}

--- a/src/main/resources/downfallResources/localization/eng/PowerStrings.json
+++ b/src/main/resources/downfallResources/localization/eng/PowerStrings.json
@@ -40,6 +40,12 @@
       "At the end of your turn, choose a card to #yExhaust."
     ]
   },
+  "downfall:SpotWeakness": {
+    "NAME": "Spot Weakness",
+    "DESCRIPTIONS": [
+      "Every turn in which you play an attack card with this power active, this enemy gains #b"," #yStrength. Currently it will gain #b", " #yStrength."
+    ]
+  },
   "downfall:PoisonResist": {
     "NAME": "Poison Resistance",
     "DESCRIPTIONS": [


### PR DESCRIPTION
Relics added:
Duality
Runic Capacitor
Sozu

Relics fixed:
Inserter (now copying the right thing)
Akabeko (no longer triggers on attacks vs boss)

Cards added:
Fusion
Phantasmal Killer
Skewer
Lesson Learned
Master Reality
Meditate
Spot Weakness

Cards fixed:
Reinforced body (now actually Defend and uses right energy)
Tranquility (no longer suggested it blocks)
Sword boomerang (now actually does multidamage for intent purposes)
Deva form (now states correct energy gain on mouseover)
Carve reality (now gives correct damage with master reality, appears in sensible place in hand and gives full damage in intent)
Fusion (plasma now triggers at end of boss turn (letting player see actual boss energy) and is no longer affected by focus)