### PR TITLE
Minor card text fix: Preprogram

### DIFF
--- a/src/main/resources/guardianResources/localization/eng/CardStrings.json
+++ b/src/main/resources/guardianResources/localization/eng/CardStrings.json
@@ -200,7 +200,7 @@
   },
   "Guardian:Preprogram": {
     "NAME": "Preprogram",
-    "DESCRIPTION": "Look at the top !M! cards of your draw pile. You may choose one to place into guardianmod:Stasis."
+    "DESCRIPTION": "Look at the top !M! cards of your draw pile. Choose one and place it into guardianmod:Stasis."
   },
   "Guardian:GemFinder": {
     "NAME": "Gem Finder",


### PR DESCRIPTION
Change Preprogram text to indicate that placing a card into stasis is mandatory, not optional.