### PR TITLE
Small update final branch

### DIFF
--- a/src/main/java/automaton/relics/DecasWashers.java
+++ b/src/main/java/automaton/relics/DecasWashers.java
@@ -1,6 +1,7 @@
 package automaton.relics;
 
 import automaton.AutomatonMod;
+import com.megacrit.cardcrawl.actions.common.GainBlockAction;
 import downfall.util.TextureLoader;
 import basemod.abstracts.CustomRelic;
 import basemod.helpers.CardPowerTip;
@@ -22,15 +23,30 @@ public class DecasWashers extends CustomRelic {
 
     public DecasWashers() {
         super(ID, IMG, OUTLINE, RelicTier.UNCOMMON, LandingSound.MAGICAL);
-        tips.add(new CardPowerTip(new Dazed()));
     }
 
-    @Override
     public void atBattleStart() {
-        flash();
-        addToBot(new RelicAboveCreatureAction(AbstractDungeon.player, this));
-        addToBot(new DrawCardAction(AbstractDungeon.player, 3));
-        addToBot(new MakeTempCardInDrawPileAction(new Dazed(), 1, true, true));
+        this.counter = 0;
+        this.grayscale = false;
+    }
+
+    public void atTurnStart() {
+        if (!this.grayscale) {
+            this.flash();
+            this.addToBot(new RelicAboveCreatureAction(AbstractDungeon.player, this));
+            addToBot(new DrawCardAction(AbstractDungeon.player, 1));
+            ++this.counter;
+        }
+
+        if (this.counter == 3) {
+            this.counter = -1;
+            this.grayscale = true;
+        }
+    }
+
+    public void onVictory() {
+        this.counter = -1;
+        this.grayscale = false;
     }
 
     @Override

--- a/src/main/java/champ/cards/AdrenalArmor.java
+++ b/src/main/java/champ/cards/AdrenalArmor.java
@@ -1,31 +1,17 @@
 package champ.cards;
 
-import champ.ChampMod;
-import com.megacrit.cardcrawl.actions.AbstractGameAction;
-import com.megacrit.cardcrawl.actions.GameActionManager;
-import com.megacrit.cardcrawl.cards.AbstractCard;
 import com.megacrit.cardcrawl.characters.AbstractPlayer;
 import com.megacrit.cardcrawl.monsters.AbstractMonster;
 import com.megacrit.cardcrawl.powers.LoseStrengthPower;
 import com.megacrit.cardcrawl.powers.StrengthPower;
 
-import static champ.ChampMod.fatigue;
-
 public class AdrenalArmor extends AbstractChampCard {
-
     public final static String ID = makeID("AdrenalArmor");
-
-    //stupid intellij stuff skill, self, common
-
-    private static final int BLOCK = 7;
-    private static final int MAGIC = 2;
 
     public AdrenalArmor() {
         super(ID, 1, CardType.SKILL, CardRarity.COMMON, CardTarget.SELF);
-        baseBlock = BLOCK;
-        baseMagicNumber = magicNumber = MAGIC;
-        //tags.add(ChampMod.COMBO);
-        //tags.add(ChampMod.COMBOBERSERKER);
+        baseBlock = 7;
+        baseMagicNumber = magicNumber = 2;
     }
 
     public void use(AbstractPlayer p, AbstractMonster m) {
@@ -34,13 +20,8 @@ public class AdrenalArmor extends AbstractChampCard {
         applyToSelf(new LoseStrengthPower(p, magicNumber));
     }
 
-    @Override
-    public void triggerOnGlowCheck() {
-        glowColor = bcombo() ? GOLD_BORDER_GLOW_COLOR : BLUE_BORDER_GLOW_COLOR;
-    }
-
     public void upp() {
         upgradeBlock(2);
-        upgradeMagicNumber(2);
+        upgradeMagicNumber(1);
     }
 }

--- a/src/main/java/downfall/cardmods/EtherealMod.java
+++ b/src/main/java/downfall/cardmods/EtherealMod.java
@@ -16,7 +16,7 @@ public class EtherealMod extends AbstractCardModifier {
     }
 
     public boolean shouldApply(AbstractCard card) {
-        return !CardModifierManager.hasModifier(card, ID);
+        return !(card.isEthereal || card.selfRetain);
     }
 
     @Override

--- a/src/main/java/downfall/cardmods/ExhaustMod.java
+++ b/src/main/java/downfall/cardmods/ExhaustMod.java
@@ -18,12 +18,17 @@ public class ExhaustMod extends AbstractCardModifier {
     }
 
     public boolean shouldApply(AbstractCard card) {
-        return !CardModifierManager.hasModifier(card, ID);
+        return !card.exhaust;
     }
 
     @Override
     public void onInitialApplication(AbstractCard card) {
         card.exhaust = true;
+    }
+
+    @Override
+    public void onRemove(AbstractCard card) {
+        card.exhaust = false;
     }
 
     @Override

--- a/src/main/java/downfall/cardmods/RetainCardMod.java
+++ b/src/main/java/downfall/cardmods/RetainCardMod.java
@@ -17,7 +17,7 @@ public class RetainCardMod extends AbstractCardModifier {
     }
 
     public boolean shouldApply(AbstractCard card) {
-        return !CardModifierManager.hasModifier(card, ID);
+        return !(card.isEthereal || card.selfRetain);
     }
 
     @Override

--- a/src/main/java/downfall/powers/neowpowers/TrueNeowPower.java
+++ b/src/main/java/downfall/powers/neowpowers/TrueNeowPower.java
@@ -6,6 +6,7 @@ import com.badlogic.gdx.graphics.g2d.TextureAtlas;
 import com.megacrit.cardcrawl.actions.common.ApplyPowerAction;
 import com.megacrit.cardcrawl.actions.common.MakeTempCardInDrawPileAction;
 import com.megacrit.cardcrawl.cards.AbstractCard;
+import com.megacrit.cardcrawl.cards.curses.Decay;
 import com.megacrit.cardcrawl.core.AbstractCreature;
 import com.megacrit.cardcrawl.core.CardCrawlGame;
 import com.megacrit.cardcrawl.core.Settings;
@@ -69,9 +70,7 @@ public class TrueNeowPower extends AbstractBossMechanicPower {
             addToBot(new ApplyPowerAction(this.owner, this.owner, new NeowMantraPower(owner, 5), 5));
         }
         if (hermit){
-            ArrayList<AbstractCard> ac = downfallMod.getRandomDownfallCurse(2);
-            AbstractDungeon.actionManager.addToBottom(new MakeTempCardInDrawPileAction(ac.get(0).makeStatEquivalentCopy(), 1, true, false, false, (float) Settings.WIDTH * 0.35F, (float) Settings.HEIGHT / 2.0F));
-            AbstractDungeon.actionManager.addToBottom(new MakeTempCardInDrawPileAction(ac.get(1).makeStatEquivalentCopy(), 1, true, false, false, (float) Settings.WIDTH * 0.65F, (float) Settings.HEIGHT / 2.0F));
+            addToBot(new MakeTempCardInDrawPileAction(new Decay(), 1, true, false, false, (float) Settings.WIDTH * 0.35F, (float) Settings.HEIGHT / 2.0F));
         }
     }
 

--- a/src/main/java/gremlin/cards/SupplyScrollCard.java
+++ b/src/main/java/gremlin/cards/SupplyScrollCard.java
@@ -13,12 +13,10 @@ import com.megacrit.cardcrawl.helpers.CardLibrary;
 import com.megacrit.cardcrawl.localization.CardStrings;
 import com.megacrit.cardcrawl.monsters.AbstractMonster;
 import gremlin.GremlinMod;
-import gremlin.powers.PolishPower;
 
 import java.util.ArrayList;
 
-import static gremlin.relics.SupplyScroll.SUPPLY;
-
+@Deprecated
 public class SupplyScrollCard extends CustomCard {
     public static final String ID = "Gremlin:SupplyScrollCard";
     private static final CardStrings strings = CardCrawlGame.languagePack.getCardStrings(ID);
@@ -44,7 +42,7 @@ public class SupplyScrollCard extends CustomCard {
         this.cardsToPreview = new Shiv();
         this.exhaust = true;
 
-        this.baseMagicNumber = this.magicNumber = SUPPLY;
+        this.baseMagicNumber = this.magicNumber = 4;
     }
 
     public void use(AbstractPlayer p, AbstractMonster m) {

--- a/src/main/java/gremlin/relics/ImpeccablePecs.java
+++ b/src/main/java/gremlin/relics/ImpeccablePecs.java
@@ -22,6 +22,8 @@ public class ImpeccablePecs extends AbstractGremlinRelic {
         super(ID, IMG, TIER, SOUND);
     }
 
+    //TODO Rework this Relic at some point
+
     @Override
     public String getUpdatedDescription() {
         return strings.DESCRIPTIONS[0];

--- a/src/main/java/gremlin/relics/SupplyScroll.java
+++ b/src/main/java/gremlin/relics/SupplyScroll.java
@@ -1,28 +1,22 @@
 package gremlin.relics;
 
-import basemod.helpers.CardPowerTip;
-import com.megacrit.cardcrawl.actions.common.MakeTempCardInHandAction;
+import com.megacrit.cardcrawl.actions.common.DrawCardAction;
+import com.megacrit.cardcrawl.actions.common.GainEnergyAction;
 import com.megacrit.cardcrawl.actions.common.RelicAboveCreatureAction;
-import com.megacrit.cardcrawl.cards.tempCards.Shiv;
 import com.megacrit.cardcrawl.core.CardCrawlGame;
 import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
 import com.megacrit.cardcrawl.localization.RelicStrings;
 import com.megacrit.cardcrawl.relics.AbstractRelic;
-import gremlin.cards.SupplyScrollCard;
-import gremlin.cards.Ward;
 
 public class SupplyScroll extends AbstractGremlinRelic {
     public static final String ID = getID("SupplyScroll");
     private static final RelicStrings strings = CardCrawlGame.languagePack.getRelicStrings(ID);
-    private static final AbstractRelic.RelicTier TIER = RelicTier.COMMON;
+    private static final AbstractRelic.RelicTier TIER = RelicTier.RARE;
     private static final String IMG = "relics/supply_scroll.png";
     private static final AbstractRelic.LandingSound SOUND = LandingSound.FLAT;
 
-    public static final int SUPPLY = 4;
-
     public SupplyScroll() {
         super(ID, IMG, TIER, SOUND);
-        this.tips.add(new CardPowerTip(new SupplyScrollCard()));
     }
 
     @Override
@@ -42,7 +36,8 @@ public class SupplyScroll extends AbstractGremlinRelic {
         if (this.counter == 3) {
             this.flash();
             this.addToBot(new RelicAboveCreatureAction(AbstractDungeon.player, this));
-            AbstractDungeon.actionManager.addToBottom(new MakeTempCardInHandAction(new SupplyScrollCard()));
+            addToBot(new GainEnergyAction(1));
+            addToBot(new DrawCardAction(2));
 
             this.counter = -1;
             this.grayscale = true;

--- a/src/main/java/guardian/powers/FloatingOrbsPower.java
+++ b/src/main/java/guardian/powers/FloatingOrbsPower.java
@@ -42,7 +42,6 @@ public class FloatingOrbsPower extends AbstractGuardianPower {
 
     @Override
     public void onInitialApplication() {
-        super.onInitialApplication();
         this.orbVFX = new FloatingOrbsEffect(this.owner, this.owner.hb.cX, this.owner.hb.cY + yOffset);
         addToBot(new VFXAction(this.orbVFX));
     }
@@ -54,6 +53,16 @@ public class FloatingOrbsPower extends AbstractGuardianPower {
             orbVFX.attackAnim();
             addToBot(new DamageRandomEnemyAction(new DamageInfo(owner, this.amount, DamageInfo.DamageType.THORNS), AbstractGameAction.AttackEffect.BLUNT_HEAVY));
         }
+    }
+
+    @Override
+    public void onVictory() {
+        orbVFX.dispose();
+    }
+
+    @Override
+    public void onRemove() {
+        orbVFX.dispose();
     }
 }
 

--- a/src/main/java/guardian/relics/PocketSentry.java
+++ b/src/main/java/guardian/relics/PocketSentry.java
@@ -26,7 +26,6 @@ public class PocketSentry extends CustomRelic {
     public static final String IMG_PATH = "relics/pocketSentry.png";
     public static final String OUTLINE_IMG_PATH = "relics/pocketSentryOutline.png";
     public static final String LARGE_IMG_PATH = "relics/pocketSentryLarge.png";
-    private static final int DAMAGE = 7;
 
     public PocketSentry() {
         super(ID, new Texture(GuardianMod.getResourcePath(IMG_PATH)), new Texture(GuardianMod.getResourcePath(OUTLINE_IMG_PATH)),
@@ -36,32 +35,23 @@ public class PocketSentry extends CustomRelic {
 
     @Override
     public String getUpdatedDescription() {
-        return this.DESCRIPTIONS[0] + DAMAGE + this.DESCRIPTIONS[1];
+        return this.DESCRIPTIONS[0];
     }
 
-    @Override
-    public void atTurnStartPostDraw() {
-        super.atTurnStartPostDraw();
-        this.flash();
-        if (counter == 0) {
-            counter = 1;
-            AbstractRelic r = this;
-            addToBot(new AbstractGameAction() {
-                @Override
-                public void update() {
-                    isDone = true;
-                    AbstractMonster m = AbstractDungeon.getMonsters().getRandomMonster(null,true,AbstractDungeon.relicRng);
-                    if(m != null){
-                        AbstractDungeon.actionManager.addToTop(new PseudoDamageRandomEnemyAction(m, new DamageInfo(AbstractDungeon.player, DAMAGE, DamageInfo.DamageType.THORNS), AbstractGameAction.AttackEffect.FIRE));
-                        AbstractDungeon.actionManager.addToTop(new VFXAction(new SmallLaserEffect(r.hb.cX - (5F * Settings.scale), r.hb.cY + (10F * Settings.scale), m.hb.cX, m.hb.cY), 0.3F));
-                        AbstractDungeon.actionManager.addToTop(new SFXAction("ATTACK_MAGIC_BEAM_SHORT", 0.5F));
-                    }
-                }
-            });
+    public void onEquip() {
+        this.counter = 0;
+    }
 
-
+    public void atTurnStart() {
+        if (this.counter == -1) {
+            this.counter += 2;
         } else {
-            counter = 0;
+            ++this.counter;
+        }
+
+        if (this.counter == 3) {
+            this.counter = 0;
+            this.flash();
             AbstractRelic r = this;
             addToBot(new AbstractGameAction() {
                 @Override

--- a/src/main/java/hermit/HermitMod.java
+++ b/src/main/java/hermit/HermitMod.java
@@ -84,6 +84,8 @@ public class HermitMod implements
         PostInitializeSubscriber,
         AddAudioSubscriber,
         OnStartBattleSubscriber,
+        OnPlayerTurnStartSubscriber,
+        OnCardUseSubscriber,
         SetUnlocksSubscriber {
     // Make sure to implement the subscribers *you* are using (read basemod wiki). Editing cards? EditCardsSubscriber.
     // Making relics? EditRelicsSubscriber. etc., etc., for a full list and how to make your own, visit the basemod wiki.
@@ -114,13 +116,6 @@ public class HermitMod implements
     public static final Color PLACEHOLDER_POTION_LIQUID = CardHelper.getColor(209.0f, 53.0f, 18.0f); // Orange-ish Red
     public static final Color PLACEHOLDER_POTION_HYBRID = CardHelper.getColor(255.0f, 230.0f, 230.0f); // Near White
     public static final Color PLACEHOLDER_POTION_SPOTS = CardHelper.getColor(100.0f, 25.0f, 10.0f); // Super Dark Red/Brown
-
-    // ONCE YOU CHANGE YOUR MOD ID (BELOW, YOU CAN'T MISS IT) CHANGE THESE PATHS!!!!!!!!!!!
-    // ONCE YOU CHANGE YOUR MOD ID (BELOW, YOU CAN'T MISS IT) CHANGE THESE PATHS!!!!!!!!!!!
-    // ONCE YOU CHANGE YOUR MOD ID (BELOW, YOU CAN'T MISS IT) CHANGE THESE PATHS!!!!!!!!!!!
-    // ONCE YOU CHANGE YOUR MOD ID (BELOW, YOU CAN'T MISS IT) CHANGE THESE PATHS!!!!!!!!!!!
-    // ONCE YOU CHANGE YOUR MOD ID (BELOW, YOU CAN'T MISS IT) CHANGE THESE PATHS!!!!!!!!!!!
-    // ONCE YOU CHANGE YOUR MOD ID (BELOW, YOU CAN'T MISS IT) CHANGE THESE PATHS!!!!!!!!!!!
 
     // Card backgrounds - The actual rectangular card.
     private static final String ATTACK_DEFAULT_GRAY = "hermitResources/images/512/bg_attack_default_gray.png";
@@ -191,30 +186,8 @@ public class HermitMod implements
         System.out.println("Subscribe to BaseMod hooks");
 
         BaseMod.subscribe(this);
-        
-      /*
-           (   ( /(  (     ( /( (            (  `   ( /( )\ )    )\ ))\ )
-           )\  )\()) )\    )\()))\ )   (     )\))(  )\()|()/(   (()/(()/(
-         (((_)((_)((((_)( ((_)\(()/(   )\   ((_)()\((_)\ /(_))   /(_))(_))
-         )\___ _((_)\ _ )\ _((_)/(_))_((_)  (_()((_) ((_|_))_  _(_))(_))_
-        ((/ __| || (_)_\(_) \| |/ __| __| |  \/  |/ _ \|   \  |_ _||   (_)
-         | (__| __ |/ _ \ | .` | (_ | _|  | |\/| | (_) | |) |  | | | |) |
-          \___|_||_/_/ \_\|_|\_|\___|___| |_|  |_|\___/|___/  |___||___(_)
-      */
 
         modID = ("hermit");
-        // cool
-        // TODO: NOW READ THIS!!!!!!!!!!!!!!!:
-
-        // 1. Go to your resources folder in the project panel, and refactor> rename hermitResources to
-        // yourModIDResources.
-
-        // 2. Click on the localization > eng folder and press ctrl+shift+r, then select "Directory" (rather than in Project)
-        // replace all instances of theDefault with yourModID.
-        // Because your mod ID isn't the default. Your cards (and everything else) should have Your mod id. Not mine.
-
-        // 3. FINALLY and most importantly: Scroll up a bit. You may have noticed the image locations above don't use getModID()
-        // Change their locations to reflect your actual ID rather than theDefault. They get loaded before getID is a thing.
 
         System.out.println("Done subscribing");
 
@@ -605,7 +578,18 @@ public class HermitMod implements
 
      */
 
+    @Override
+    public void receiveCardUsed(AbstractCard abstractCard) {
+        AbstractHermitCard.deadOnThisTurn.add(false);
+    }
+
+    @Override
+    public void receiveOnPlayerTurnStart() {
+        AbstractHermitCard.deadOnThisTurn.clear();
+    }
+
     public void receiveOnBattleStart(AbstractRoom room) {
+        AbstractHermitCard.deadOnThisTurn.clear();
         tackybypass = true;
         if (AbstractDungeon.player instanceof hermit) {
             if (downfallMod.unseenTutorials[0]) {

--- a/src/main/java/hermit/cards/AbstractHermitCard.java
+++ b/src/main/java/hermit/cards/AbstractHermitCard.java
@@ -46,7 +46,7 @@ public abstract class AbstractHermitCard extends CustomCard {
     public boolean upgradedDefaultSecondMagicNumber;
     public boolean isDefaultSecondMagicNumberModified;
     public static boolean lastCardDeadOn = false;
-    public static ArrayList deadOnThisTurn = new ArrayList();
+    public static ArrayList<Boolean> deadOnThisTurn = new ArrayList<>();
 
     public AbstractHermitCard(final String id,
                               final String name,
@@ -145,11 +145,12 @@ public abstract class AbstractHermitCard extends CustomCard {
                 if (c.relicId.equals(BlackPowder.ID))
                 {
                     ((BlackPowder)c).PowderCharge += 2;
-                    ((BlackPowder)c).counter = ((BlackPowder)c).PowderCharge;
+                    c.counter = ((BlackPowder)c).PowderCharge;
                 }
             }
 
-            //AbstractHermitCard.deadOnThisTurn.set(AbstractHermitCard.deadOnThisTurn.size()-1,true); TODO - Fix this crashing mess
+            if (deadOnThisTurn.size() > 0)
+                AbstractHermitCard.deadOnThisTurn.set(deadOnThisTurn.size() - 1,true);
             EndOfTurnPatch.deadon_counter++;
         }
 

--- a/src/main/java/hermit/cards/CalledShot.java
+++ b/src/main/java/hermit/cards/CalledShot.java
@@ -50,13 +50,13 @@ public class CalledShot extends AbstractDynamicCard {
     @Override
     public void use(AbstractPlayer p, AbstractMonster m) {
         this.addToBot(new DamageAction(m, new DamageInfo(p, this.damage, DamageInfo.DamageType.NORMAL), EnumPatch.HERMIT_GUN2));
-        if (deadOnThisTurn.size() >= 2 && deadOnThisTurn.get(deadOnThisTurn.size() - 2).equals(true))
+        if (deadOnThisTurn.size() >= 2 && deadOnThisTurn.get(deadOnThisTurn.size() - 2))
             Wiz.atb(new DrawCardAction(1));
     }
 
     public void triggerOnGlowCheck() {
         this.glowColor = AbstractDynamicCard.BLUE_BORDER_GLOW_COLOR.cpy();
-        if (!deadOnThisTurn.isEmpty() && deadOnThisTurn.get(deadOnThisTurn.size() - 1).equals(true))
+        if (!deadOnThisTurn.isEmpty() && deadOnThisTurn.get(deadOnThisTurn.size() - 1))
             this.glowColor = AbstractDynamicCard.GOLD_BORDER_GLOW_COLOR.cpy();
     }
 

--- a/src/main/java/hermit/cards/Gambit.java
+++ b/src/main/java/hermit/cards/Gambit.java
@@ -57,11 +57,18 @@ public class Gambit extends AbstractDynamicCard {
         Wiz.atb(new AbstractGameAction() {
             @Override
             public void update() {
+                int counter = 0;
+
                 CardGroup tmp = new CardGroup(CardGroup.CardGroupType.UNSPECIFIED);
+
                 tmp.group = (ArrayList<AbstractCard>) Wiz.p().discardPile.group.stream()
                         .filter(c -> c.type == CardType.ATTACK)
                         .collect(Collectors.toList());
+
                 for (AbstractCard c : tmp.group) {
+                    if (counter >= Gambit.this.magicNumber)
+                        break;
+
                     if (!tmp.isEmpty() && Wiz.hand().size() < BaseMod.MAX_HAND_SIZE) {
                         c.unhover();
                         c.lighten(true);
@@ -76,6 +83,7 @@ public class Gambit extends AbstractDynamicCard {
                         AbstractDungeon.player.hand.refreshHandLayout();
                         AbstractDungeon.player.hand.applyPowers();
                         this.addToTop( new ReduceCostForTurnAction(c,1));
+                        counter++;
                     }
                 }
                 isDone = true;

--- a/src/main/java/slimebound/cards/Nibble.java
+++ b/src/main/java/slimebound/cards/Nibble.java
@@ -1,90 +1,60 @@
 package slimebound.cards;
 
 
-import com.badlogic.gdx.graphics.Color;
 import com.megacrit.cardcrawl.actions.AbstractGameAction;
-import com.megacrit.cardcrawl.actions.animations.VFXAction;
-import com.megacrit.cardcrawl.actions.common.ApplyPowerAction;
 import com.megacrit.cardcrawl.actions.common.DamageAction;
 import com.megacrit.cardcrawl.actions.common.DrawCardAction;
 import com.megacrit.cardcrawl.actions.common.MakeTempCardInHandAction;
-import com.megacrit.cardcrawl.actions.utility.WaitAction;
 import com.megacrit.cardcrawl.cards.AbstractCard;
 import com.megacrit.cardcrawl.cards.DamageInfo;
 import com.megacrit.cardcrawl.characters.AbstractPlayer;
 import com.megacrit.cardcrawl.core.CardCrawlGame;
 import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
-import com.megacrit.cardcrawl.helpers.CardLibrary;
 import com.megacrit.cardcrawl.localization.CardStrings;
 import com.megacrit.cardcrawl.monsters.AbstractMonster;
 import slimebound.SlimeboundMod;
 import slimebound.patches.AbstractCardEnum;
-import slimebound.powers.SlimedPower;
-import slimebound.vfx.LickEffect;
 import slimebound.vfx.SlimeDripsEffect;
-
-import java.util.ArrayList;
-
-import static com.badlogic.gdx.graphics.Color.GREEN;
 
 
 public class Nibble extends AbstractSlimeboundCard {
     public static final String ID = "Slimebound:Nibble";
-    public static final String NAME;
-    public static final String DESCRIPTION;
-    public static final String IMG_PATH = "cards/nibble.png";
+    public static final String IMG_PATH = SlimeboundMod.getResourcePath("cards/nibble.png");
     private static final CardStrings cardStrings;
-    private static final CardType TYPE = CardType.ATTACK;
-    private static final CardRarity RARITY = CardRarity.UNCOMMON;
-    private static final CardTarget TARGET = CardTarget.ENEMY;
-    private static final int COST = 0;
-    public static String UPGRADED_DESCRIPTION;
-    private static int upgradedamount = 1;
-
-    static {
-        cardStrings = CardCrawlGame.languagePack.getCardStrings(ID);
-        NAME = cardStrings.NAME;
-        DESCRIPTION = cardStrings.DESCRIPTION;
-        UPGRADED_DESCRIPTION = cardStrings.UPGRADE_DESCRIPTION;
-    }
 
     public Nibble() {
-        super(ID, NAME, SlimeboundMod.getResourcePath(IMG_PATH), COST, DESCRIPTION, TYPE, AbstractCardEnum.SLIMEBOUND, RARITY, TARGET);
-        baseDamage = damage = 1;
-        tags.add(SlimeboundMod.LICK);
-       // this.slimed = this.baseSlimed = 4;
+        super(ID, cardStrings.NAME, IMG_PATH, 0, cardStrings.DESCRIPTION, CardType.ATTACK, AbstractCardEnum.SLIMEBOUND, CardRarity.UNCOMMON, CardTarget.ENEMY);
+        baseDamage = damage = 4;
         this.exhaust = true;
+        tags.add(SlimeboundMod.LICK);
         this.cardsToPreview = new Lick();
     }
 
     public void use(AbstractPlayer p, AbstractMonster m) {
         addToBot(new DamageAction(m, new DamageInfo(p, damage, damageTypeForTurn), AbstractGameAction.AttackEffect.BLUNT_LIGHT));
-
         AbstractDungeon.effectsQueue.add(new SlimeDripsEffect(m.hb.cX, m.hb.cY, 3));
-        //AbstractDungeon.actionManager.addToBottom(new ApplyPowerAction(m, p, new WeakPower(m, this.magicNumber, false), this.magicNumber, true, AbstractGameAction.AttackEffect.NONE));
-
         AbstractDungeon.actionManager.addToBottom(new MakeTempCardInHandAction(new Lick()));
         if (upgraded) upgradeAction(p,m);
-
-    }
-
-
-
-    public void upgradeAction(AbstractPlayer p, AbstractMonster m){
-        AbstractDungeon.actionManager.addToBottom(new DrawCardAction(p, 1));
-    }
-
-
-    public AbstractCard makeCopy() {
-        return new Nibble();
     }
 
     public void upgrade() {
         if (!this.upgraded) {
             upgradeName();
-            this.rawDescription = UPGRADED_DESCRIPTION;
+            this.rawDescription = cardStrings.UPGRADE_DESCRIPTION;
             this.initializeDescription();
         }
+    }
+
+    public void upgradeAction(AbstractPlayer p, AbstractMonster m){
+        AbstractDungeon.actionManager.addToBottom(new DrawCardAction(p, 1));
+    }
+
+    public AbstractCard makeCopy() {
+        return new Nibble();
+    }
+
+    static {
+        cardStrings = CardCrawlGame.languagePack.getCardStrings(ID);
     }
 }
 

--- a/src/main/java/slimebound/cards/SlimeSlap.java
+++ b/src/main/java/slimebound/cards/SlimeSlap.java
@@ -50,6 +50,11 @@ public class SlimeSlap extends AbstractSlimeboundCard {
         }
     }
 
+    @Override
+    public void triggerOnGlowCheck() {
+        slimedGlowCheck();
+    }
+
     public AbstractCard makeCopy() {
         return new SlimeSlap();
     }

--- a/src/main/java/slimebound/cards/Teamwork.java
+++ b/src/main/java/slimebound/cards/Teamwork.java
@@ -7,8 +7,6 @@ import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
 import com.megacrit.cardcrawl.localization.CardStrings;
 import com.megacrit.cardcrawl.monsters.AbstractMonster;
 import com.megacrit.cardcrawl.ui.panels.EnergyPanel;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import slimebound.SlimeboundMod;
 import slimebound.actions.CoordinateAction;
 import slimebound.patches.AbstractCardEnum;
@@ -16,29 +14,12 @@ import slimebound.patches.AbstractCardEnum;
 
 public class Teamwork extends AbstractSlimeboundCard {
     public static final String ID = "Slimebound:Teamwork";
-    public static final String NAME;
-    public static final String DESCRIPTION;
-    public static final String IMG_PATH = "cards/coordinatedstrike.png";
-    public static final Logger logger = LogManager.getLogger(SlimeboundMod.class.getName());
-    private static final CardType TYPE = CardType.SKILL;
-    private static final CardRarity RARITY = CardRarity.RARE;
-    private static final CardTarget TARGET = CardTarget.SELF;
-
+    public static final String IMG_PATH = SlimeboundMod.getResourcePath("cards/coordinatedstrike.png");
     private static final CardStrings cardStrings;
-    private static final int COST = -1;
-    public static String UPGRADED_DESCRIPTION;
-
-    static {
-        cardStrings = CardCrawlGame.languagePack.getCardStrings(ID);
-        NAME = cardStrings.NAME;
-        DESCRIPTION = cardStrings.DESCRIPTION;
-        UPGRADED_DESCRIPTION = cardStrings.UPGRADE_DESCRIPTION;
-    }
 
     public Teamwork() {
-        super(ID, NAME, SlimeboundMod.getResourcePath(IMG_PATH), COST, DESCRIPTION, TYPE, AbstractCardEnum.SLIMEBOUND, RARITY, TARGET);
+        super(ID, cardStrings.NAME, IMG_PATH, -1, cardStrings.DESCRIPTION, CardType.SKILL, AbstractCardEnum.SLIMEBOUND, CardRarity.RARE, CardTarget.SELF);
         baseBlock = 5;
-        //this.exhaust = true;
         SlimeboundMod.loadJokeCardImage(this, "Teamwork.png");
     }
 
@@ -46,18 +27,20 @@ public class Teamwork extends AbstractSlimeboundCard {
         if (this.energyOnUse < EnergyPanel.totalCount) {
             this.energyOnUse = EnergyPanel.totalCount;
         }
-        AbstractDungeon.actionManager.addToBottom(new CoordinateAction(p, m, this.magicNumber, this.freeToPlayOnce, this.energyOnUse, block, upgraded));
+        AbstractDungeon.actionManager.addToBottom(new CoordinateAction(p, m, this.magicNumber, this.freeToPlayOnce, this.energyOnUse, block, false));
 
         checkMinionMaster();
     }
 
-
     public void upgrade() {
         if (!this.upgraded) {
             upgradeName();
-            rawDescription = UPGRADED_DESCRIPTION;
-            initializeDescription();
+            upgradeBlock(3);
         }
+    }
+
+    static {
+        cardStrings = CardCrawlGame.languagePack.getCardStrings(ID);
     }
 }
 

--- a/src/main/java/slimebound/relics/AbsorbEndCombat.java
+++ b/src/main/java/slimebound/relics/AbsorbEndCombat.java
@@ -2,6 +2,7 @@ package slimebound.relics;
 
 import basemod.abstracts.CustomRelic;
 import com.badlogic.gdx.graphics.Texture;
+import com.megacrit.cardcrawl.actions.common.RelicAboveCreatureAction;
 import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
 import com.megacrit.cardcrawl.helpers.RelicLibrary;
 import com.megacrit.cardcrawl.relics.AbstractRelic;
@@ -33,8 +34,9 @@ public class AbsorbEndCombat extends CustomRelic {
     public void onTrigger() {
         int realAmount = Math.min(HP_PER_SLURP, counter);
         if (realAmount > 0) {
-            AbstractDungeon.actionManager.addToBottom(new com.megacrit.cardcrawl.actions.common.HealAction(AbstractDungeon.player, AbstractDungeon.player, realAmount));
             flash();
+            addToBot(new RelicAboveCreatureAction(AbstractDungeon.player, this));
+            addToBot(new com.megacrit.cardcrawl.actions.common.HealAction(AbstractDungeon.player, AbstractDungeon.player, realAmount));
             counter -= realAmount;
             if (counter == 0) {
                 grayscale = true;

--- a/src/main/java/slimebound/relics/MaxSlimesRelic.java
+++ b/src/main/java/slimebound/relics/MaxSlimesRelic.java
@@ -2,12 +2,12 @@ package slimebound.relics;
 
 import basemod.abstracts.CustomRelic;
 import com.badlogic.gdx.graphics.Texture;
+import com.megacrit.cardcrawl.actions.defect.IncreaseMaxOrbAction;
 import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
 import com.megacrit.cardcrawl.helpers.ImageMaster;
 import com.megacrit.cardcrawl.relics.AbstractRelic;
-import slimebound.actions.SlimeSpawnAction;
+import slimebound.SlimeboundMod;
 import slimebound.characters.SlimeboundCharacter;
-import slimebound.orbs.ShieldSlime;
 
 public class MaxSlimesRelic extends CustomRelic {
     public static final String ID = "Slimebound:MaxSlimesRelic";
@@ -29,8 +29,8 @@ public class MaxSlimesRelic extends CustomRelic {
 
     public void atBattleStartPreDraw() {
         this.flash();
-        com.megacrit.cardcrawl.dungeons.AbstractDungeon.actionManager.addToBottom(new com.megacrit.cardcrawl.actions.defect.IncreaseMaxOrbAction(1));
-        AbstractDungeon.actionManager.addToBottom(new SlimeSpawnAction(new ShieldSlime(), false, true));
+        addToBot(new IncreaseMaxOrbAction(1));
+        SlimeboundMod.spawnNormalSlime();
     }
 
     public boolean canSpawn() {

--- a/src/main/java/slimebound/relics/PotencyRelic.java
+++ b/src/main/java/slimebound/relics/PotencyRelic.java
@@ -3,6 +3,7 @@ package slimebound.relics;
 import basemod.abstracts.CustomRelic;
 import com.badlogic.gdx.graphics.Texture;
 import com.megacrit.cardcrawl.actions.common.ApplyPowerAction;
+import com.megacrit.cardcrawl.actions.common.RelicAboveCreatureAction;
 import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
 import com.megacrit.cardcrawl.helpers.ImageMaster;
 import com.megacrit.cardcrawl.relics.AbstractRelic;
@@ -29,7 +30,8 @@ public class PotencyRelic extends CustomRelic {
     }
 
     public void atBattleStartPreDraw() {
-        this.flash();
+        flash();
+        addToBot(new RelicAboveCreatureAction(AbstractDungeon.player, this));
         addToBot(new ApplyPowerAction(AbstractDungeon.player, AbstractDungeon.player, new PotencyPower(AbstractDungeon.player, AbstractDungeon.player, 1), 1));
     }
 

--- a/src/main/java/slimebound/relics/PotencyRelic.java
+++ b/src/main/java/slimebound/relics/PotencyRelic.java
@@ -15,11 +15,10 @@ public class PotencyRelic extends CustomRelic {
     public static final String IMG_PATH = "relics/oozeStone.png";
     public static final String IMG_PATH_LARGE = "relics/oozeStonearge.png";
     public static final String OUTLINE_IMG_PATH = "relics/oozeStoneOutline.png";
-    private static final int HP_PER_CARD = 1;
 
     public PotencyRelic() {
         super(ID, new Texture(slimebound.SlimeboundMod.getResourcePath(IMG_PATH)), new Texture(slimebound.SlimeboundMod.getResourcePath(OUTLINE_IMG_PATH)),
-                RelicTier.RARE, LandingSound.MAGICAL);
+                RelicTier.COMMON, LandingSound.MAGICAL);
         this.largeImg = ImageMaster.loadImage(slimebound.SlimeboundMod.getResourcePath(IMG_PATH_LARGE));
 
     }
@@ -31,9 +30,7 @@ public class PotencyRelic extends CustomRelic {
 
     public void atBattleStartPreDraw() {
         this.flash();
-        AbstractDungeon.actionManager.addToBottom(new SlimeSpawnAction(new slimebound.orbs.SlimingSlime(), false, true));
-        AbstractDungeon.actionManager.addToBottom(new ApplyPowerAction(AbstractDungeon.player, AbstractDungeon.player, new PotencyPower(AbstractDungeon.player, AbstractDungeon.player, 1), 1));
-
+        addToBot(new ApplyPowerAction(AbstractDungeon.player, AbstractDungeon.player, new PotencyPower(AbstractDungeon.player, AbstractDungeon.player, 1), 1));
     }
 
     public boolean canSpawn() {

--- a/src/main/java/slimebound/relics/SlimedTailRelic.java
+++ b/src/main/java/slimebound/relics/SlimedTailRelic.java
@@ -2,25 +2,29 @@ package slimebound.relics;
 
 import basemod.abstracts.CustomRelic;
 import com.badlogic.gdx.graphics.Texture;
+import com.evacipated.cardcrawl.mod.stslib.relics.OnChannelRelic;
 import com.megacrit.cardcrawl.actions.AbstractGameAction;
 import com.megacrit.cardcrawl.actions.common.ApplyPowerAction;
+import com.megacrit.cardcrawl.actions.common.GainBlockAction;
 import com.megacrit.cardcrawl.actions.common.RelicAboveCreatureAction;
 import com.megacrit.cardcrawl.characters.AbstractPlayer;
 import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
 import com.megacrit.cardcrawl.helpers.ImageMaster;
 import com.megacrit.cardcrawl.helpers.PowerTip;
+import com.megacrit.cardcrawl.orbs.AbstractOrb;
 import com.megacrit.cardcrawl.relics.AbstractRelic;
 import com.megacrit.cardcrawl.rooms.AbstractRoom;
 import slimebound.actions.SlimeSpawnAction;
 import slimebound.characters.SlimeboundCharacter;
+import slimebound.orbs.SpawnedSlime;
 import slimebound.powers.SlimeSacrificePower;
 
-public class SlimedTailRelic extends CustomRelic {
+public class SlimedTailRelic extends CustomRelic implements OnChannelRelic {
     public static final String ID = "Slimebound:SlimedTailRelic";
     public static final String IMG_PATH = "relics/slimedTail.png";
     public static final String IMG_PATH_LARGE = "relics/slimedTailLarge.png";
     public static final String OUTLINE_IMG_PATH = "relics/slimedTailOutline.png";
-    private boolean isActive = false;
+    private static final int BLOCK_PER_TRIGGER = 3;
 
     public SlimedTailRelic() {
         super(ID, new Texture(slimebound.SlimeboundMod.getResourcePath(IMG_PATH)), new Texture(slimebound.SlimeboundMod.getResourcePath(OUTLINE_IMG_PATH)),
@@ -31,62 +35,13 @@ public class SlimedTailRelic extends CustomRelic {
 
     @Override
     public String getUpdatedDescription() {
-        return this.DESCRIPTIONS[0];
+        return this.DESCRIPTIONS[0] + BLOCK_PER_TRIGGER + this.DESCRIPTIONS[1];
     }
 
-    public void atBattleStart() {
-        this.isActive = true;
-        this.grayscale = false;
-        AbstractDungeon.actionManager.addToBottom(new AbstractGameAction() {
-            public void update() {
-                if (SlimedTailRelic.this.isActive && AbstractDungeon.player.isBloodied) {
-                    activate();
-
-                }
-
-                this.isDone = true;
-            }
-        });
-    }
-
-    public void activate() {
-        AbstractPlayer p = AbstractDungeon.player;
-        flash();
-
-        AbstractDungeon.actionManager.addToTop(new SlimeSpawnAction(new slimebound.orbs.PoisonSlime(true), false, false));
-
-        AbstractDungeon.actionManager.addToTop(new RelicAboveCreatureAction(p, this));
-        AbstractDungeon.actionManager.addToTop(new ApplyPowerAction(p, p, new SlimeSacrificePower(AbstractDungeon.player, 1), 1, true));
-
-        this.isActive = false;
-        AbstractDungeon.player.hand.applyPowers();
-        this.grayscale = true;
-
-        this.usedUp = true;
-        this.description = this.DESCRIPTIONS[1];
-        this.tips.clear();
-        this.tips.add(new PowerTip(this.name, this.description));
-        this.initializeTips();
-    }
-
-    public void onBloodied() {
-        if (this.isActive && AbstractDungeon.getCurrRoom().phase == AbstractRoom.RoomPhase.COMBAT) {
-            activate();
-        }
-
-    }
-
-
-    public void onVictory() {
-        if (!isActive) {
-            this.grayscale = false;
-            this.isActive = true;
-            this.usedUp = false;
-            this.description = this.getUpdatedDescription();
-
-            this.tips.clear();
-            this.tips.add(new PowerTip(this.name, this.description));
-            this.initializeTips();
+    @Override
+    public void onChannel(AbstractOrb abstractOrb) {
+        if (abstractOrb instanceof SpawnedSlime) {
+            addToBot(new GainBlockAction(AbstractDungeon.player, BLOCK_PER_TRIGGER));
         }
     }
 

--- a/src/main/java/slimebound/relics/SlimedTailRelic.java
+++ b/src/main/java/slimebound/relics/SlimedTailRelic.java
@@ -41,6 +41,8 @@ public class SlimedTailRelic extends CustomRelic implements OnChannelRelic {
     @Override
     public void onChannel(AbstractOrb abstractOrb) {
         if (abstractOrb instanceof SpawnedSlime) {
+            flash();
+            addToBot(new RelicAboveCreatureAction(AbstractDungeon.player, this));
             addToBot(new GainBlockAction(AbstractDungeon.player, BLOCK_PER_TRIGGER));
         }
     }

--- a/src/main/java/sneckomod/relics/BlankCard.java
+++ b/src/main/java/sneckomod/relics/BlankCard.java
@@ -21,48 +21,19 @@ public class BlankCard extends CustomRelic {
     private static final Texture IMG = TextureLoader.getTexture(SneckoMod.makeRelicPath("BlankCard.png"));
     private static final Texture OUTLINE = TextureLoader.getTexture(SneckoMod.makeRelicOutlinePath("BlankCard.png"));
 
-    private boolean activated;
-
     public BlankCard() {
         super(ID, IMG, OUTLINE, RelicTier.COMMON, LandingSound.MAGICAL);
     }
 
-    public void start() {
-
-    }
-
     @Override
-    public void atTurnStartPostDraw() {
-        if (!this.activated) {
-            ArrayList<AbstractCard> possCardsList = new ArrayList<>(AbstractDungeon.player.drawPile.group);
-            AbstractCard card2 = possCardsList.get(AbstractDungeon.cardRandomRng.random(possCardsList.size() - 1)).makeStatEquivalentCopy();
-//            AbstractMonster m = AbstractDungeon.getRandomMonster();
-            flash();
-            addToBot(new RelicAboveCreatureAction(AbstractDungeon.player, this));
-            AbstractDungeon.effectList.add(new ShowCardBrieflyEffect(card2.makeStatEquivalentCopy()));
-            card2.freeToPlayOnce = true;
-            AbstractDungeon.actionManager.addToBottom(new MakeEchoAction(card2));
+    public void atBattleStart() {
+        ArrayList<AbstractCard> possCardsList = new ArrayList<>(AbstractDungeon.player.drawPile.group);
+        AbstractCard card2 = possCardsList.get(AbstractDungeon.cardRandomRng.random(possCardsList.size() - 1)).makeStatEquivalentCopy();
 
-//            card2.purgeOnUse = true;
-
-
-
-
-//            AbstractDungeon.actionManager.addToBottom(new AbstractGameAction() {
-//                @Override
-//                public void update() {
-//                    card2.applyPowers();
-//                    isDone = true;
-//                }
-//            });
-//            AbstractDungeon.actionManager.addToBottom(new NewQueueCardAction(card2, m));
-            this.activated = true;
-        }
-    }
-
-    @Override
-    public void onVictory() {
-        this.activated = false;
+        flash();
+        addToBot(new RelicAboveCreatureAction(AbstractDungeon.player, this));
+        card2.freeToPlayOnce = true;
+        addToBot(new MakeEchoAction(card2));
     }
 
     public String getUpdatedDescription() {

--- a/src/main/java/theHexaghost/cards/FlameSwitch.java
+++ b/src/main/java/theHexaghost/cards/FlameSwitch.java
@@ -28,7 +28,7 @@ public class FlameSwitch extends AbstractHexaCard {
     public final static String ID = makeID("FlameSwitch");
 
     public FlameSwitch() {
-        super(ID, 1, CardType.SKILL, CardRarity.RARE, CardTarget.SELF);
+        super(ID, 1, CardType.SKILL, CardRarity.RARE, CardTarget.ENEMY);
         baseBurn = burn = 16;
         baseMagicNumber = magicNumber = 1;
         exhaust = true;
@@ -44,6 +44,7 @@ public class FlameSwitch extends AbstractHexaCard {
                 AbstractPower po = m.getPower(BurnPower.POWER_ID);
                 if (po != null) {
                     ((TwoAmountPower) po).amount2 += magicNumber;
+                    po.updateDescription();
                 }
             }
         });

--- a/src/main/resources/bronzeResources/localization/eng/RelicStrings.json
+++ b/src/main/resources/bronzeResources/localization/eng/RelicStrings.json
@@ -17,7 +17,7 @@
     "NAME": "Deca's Washers",
     "FLAVOR": "It is unclear why Deca collects these.",
     "DESCRIPTIONS": [
-      "At the start of each combat, draw #b3 additional cards and add a #yDazed into your draw pile."
+      "At the start of the first 3 turns of each combat, draw an additional card."
     ]
   },
   "bronze:Timepiece": {

--- a/src/main/resources/downfallResources/localization/eng/PowerStrings.json
+++ b/src/main/resources/downfallResources/localization/eng/PowerStrings.json
@@ -393,7 +393,7 @@
       " NL Gains #b2 Thorns. #y(Silent)",
       " NL Gains #b2 Buffer. #y(Defect)",
       " NL Gains #b5 Mantra. #y(Watcher)",
-      " NL Adds #b2 random #rCurses to your draw pile. #y(Hermit)"
+      " NL Adds a #yDecay to your draw pile. #y(Hermit)"
     ]
   }
 }

--- a/src/main/resources/gremlinResources/localization/eng/RelicStrings.json
+++ b/src/main/resources/gremlinResources/localization/eng/RelicStrings.json
@@ -98,7 +98,7 @@
     "NAME": "Supply Scroll",
     "FLAVOR": "A surprisingly detailed inventory of the mob's various bits and bobbles.",
     "DESCRIPTIONS": [
-      "At the start of your 3rd turn, gain a #ySupply #yScroll."
+      "At the start of your 3rd turn, gain [E] and draw 2 cards."
     ]
   },
   "Gremlin:TagTeamwork": {

--- a/src/main/resources/guardianResources/localization/eng/RelicStrings.json
+++ b/src/main/resources/guardianResources/localization/eng/RelicStrings.json
@@ -31,8 +31,7 @@
     "NAME": "Arumba's Pocket Sentry",
     "FLAVOR": "Sentry Mode active. Target acquired. No hard feelings.",
     "DESCRIPTIONS": [
-      "At the start of each turn, alternates between: NL Deal #b",
-      " damage to a random enemy. NL Apply #b1 #yWeak to ALL enemies."
+      "Every 3 turns, apply #b1 #yWeak to ALL enemies."
     ]
   },
   "Guardian:SackOfGems": {
@@ -60,14 +59,14 @@
     "NAME": "Wander Bots",
     "FLAVOR": "These drones find the most wonderful salvage, but require processing power to maintain.",
     "DESCRIPTIONS": [
-      "On pickup, lose #b1 Stasis slot. NL Gain [E] at the start of your turn."
+      "At the start of each combat, lose #b1 Stasis slot. NL Gain [E] at the start of your turn."
     ]
   },
   "Guardian:StasisUpgradeRelic": {
     "NAME": "Cryo Chamber",
     "FLAVOR": "Things always seem better coming out than they did going in.",
     "DESCRIPTIONS": [
-      "Gain #b1 Stasis slot. Whenever a card enters #yguardianmod:Stasis, #yUpgrade it."
+      "At the start of each combat, gain #b1 Stasis slot. Whenever a card enters #yguardianmod:Stasis, #yUpgrade it."
     ]
   },
   "Guardian:BottledStasis": {

--- a/src/main/resources/hermitResources/localization/eng/CardStrings.json
+++ b/src/main/resources/hermitResources/localization/eng/CardStrings.json
@@ -43,8 +43,8 @@
   },
   "hermit:Snipe": {
     "NAME": "Snipe",
-    "DESCRIPTION": "Your next hermit:Dead_On effect triggers twice. NL Exhaust.",
-    "UPGRADE_DESCRIPTION": "hermit:Concentrate. NL Your next hermit:Dead_On effect triggers twice. NL Exhaust."
+    "DESCRIPTION": "Your next hermit:Dead_On effect this turn triggers twice. NL Exhaust.",
+    "UPGRADE_DESCRIPTION": "hermit:Concentrate. NL Your next hermit:Dead_On effect this turn triggers twice. NL Exhaust."
   },
   "hermit:CalledShot": {
     "NAME": "Called Shot",

--- a/src/main/resources/hermitResources/localization/eng/CardStrings.json
+++ b/src/main/resources/hermitResources/localization/eng/CardStrings.json
@@ -43,14 +43,13 @@
   },
   "hermit:Snipe": {
     "NAME": "Snipe",
-    "DESCRIPTION": "Your next hermit:Dead_On effect this turn triggers twice.",
-    "UPGRADE_DESCRIPTION": "hermit:Concentrate. NL Your next hermit:Dead_On effect this turn triggers twice."
+    "DESCRIPTION": "Your next hermit:Dead_On effect triggers twice. NL Exhaust.",
+    "UPGRADE_DESCRIPTION": "hermit:Concentrate. NL Your next hermit:Dead_On effect triggers twice. NL Exhaust."
   },
   "hermit:CalledShot": {
     "NAME": "Called Shot",
-    "DESCRIPTION": "Deal damage equal to your hand size. NL hermit:Dead_On: NL Draw !M! Attack.",
-    "UPGRADE_DESCRIPTION": " NL (Deals !D! damage.)",
-    "EXTENDED_DESCRIPTION": ["Deal damage equal to your hand size. NL hermit:Dead_On: NL Draw !M! Attacks."]
+    "DESCRIPTION": "Deal !D! damage. NL If the last card played this turn triggered *Dead *On, draw a card.",
+    "UPGRADE_DESCRIPTION": "Retain. NL Deal !D! damage. NL If the last card played this turn triggered *Dead *On, draw a card."
   },
   "hermit:Dissolve": {
     "NAME": "Dissolve",
@@ -108,11 +107,11 @@
   },
   "hermit:Roulette": {
     "NAME": "Roulette",
-    "DESCRIPTION": "Deal !D! damage to a random enemy. NL Discard your hand. NL Draw that many cards."
+    "DESCRIPTION": "Deal !D! damage. NL Discard your hand. NL Draw that many cards."
   },
   "hermit:Midnight": {
     "NAME": "Midnight",
-    "DESCRIPTION": "Ethereal. NL Gain !B! Block. NL Add an *Impending *Doom to your hand.",
+    "DESCRIPTION": "Gain !B! Block. NL Add an *Impending *Doom to your hand.",
     "UPGRADE_DESCRIPTION": "Gain !B! Block. NL Add an *Impending *Doom to your hand."
   },
   "hermit:Glare": {
@@ -127,7 +126,7 @@
   },
   "hermit:Misfire": {
     "NAME": "Misfire",
-    "DESCRIPTION": "Deal !D! damage to a random enemy. NL Shuffle a *Clumsy into your draw pile."
+    "DESCRIPTION": "Deal !D! damage. NL Shuffle a *Clumsy into your draw pile."
   },
   "hermit:SprayPray": {
     "NAME": "Spray n' Pray",
@@ -155,11 +154,11 @@
   },
   "hermit:Spite": {
     "NAME": "Spite",
-    "DESCRIPTION": "Deal !D! damage twice. NL Draw !M! *Curses."
+    "DESCRIPTION": "Deal !D! damage. NL Draw a card for each *Curse in your hand."
   },
   "hermit:Manifest": {
     "NAME": "Manifest",
-    "DESCRIPTION": "Gain !B! Block. NL Gain a *Decay."
+    "DESCRIPTION": "Gain !B! Block. NL Add a *Decay to your hand."
   },
   "hermit:Feint": {
     "NAME": "Feint",
@@ -183,7 +182,8 @@
   },
   "hermit:Vantage": {
     "NAME": "Vantage",
-    "DESCRIPTION": "Gain !B! Block. NL hermit:Dead_On: NL Upgrade !M! random cards in your hand for the rest of combat."
+    "DESCRIPTION": "Gain !B! Block. NL hermit:Dead_On: NL Draw !M! card and Upgrade it for the rest of combat.",
+    "UPGRADE_DESCRIPTION": "Gain !B! Block. NL hermit:Dead_On: NL Draw !M! cards and Upgrade them for the rest of combat."
   },
   "hermit:Brawl": {
     "NAME": "Brawl",
@@ -310,7 +310,7 @@
   },
   "hermit:FinalCanter": {
     "NAME": "Final Canter",
-    "DESCRIPTION": "Retain. NL Deal !D! damage for each Curse in hand. NL Exhaust.",
+    "DESCRIPTION": "Retain. NL Exhaust all Curses in hand. Deal !D! damage for each. Exhaust.",
     "UPGRADE_DESCRIPTION": " NL (You have !M! Curse(s))"
   },
   "hermit:HeroicBravado": {

--- a/src/main/resources/slimeboundResources/localization/eng/RelicStrings.json
+++ b/src/main/resources/slimeboundResources/localization/eng/RelicStrings.json
@@ -18,15 +18,15 @@
     "NAME": "Slimed Tail",
     "FLAVOR": "A fake tail to trick enemies during combat, completely covered in slime.",
     "DESCRIPTIONS": [
-      "When you fall below #b50% of your Maximum HP, #yslimeboundmod:Split into a #yslimeboundmod:Guerilla #ySlime, and the next time you take damage, your leading slime is #yslimeboundmod:Absorbed instead. (works once per combat).",
-      "This relic has been used this combat. It will become active again next combat."
+      "Whenever you #ySplit, gain #b.",
+      " Block."
     ]
   },
   "Slimebound:PotencyRelic": {
     "NAME": "Stone of Nomakk",
     "FLAVOR": "When presented to one of your Goop Gang, it seems to make the blob dance.",
     "DESCRIPTIONS": [
-      "At the start of combat, #ySplit into a #yslimeboundmod:Mire #ySlime and gain #b1 #yslimeboundmod:Potency."
+      "At the start of combat, gain #b1 #yslimeboundmod:Potency."
     ]
   },
   "Slimebound:DailySplitRelic": {
@@ -79,7 +79,7 @@
     "NAME": "Jeremiah's Banner",
     "FLAVOR": "You and ooze army.",
     "DESCRIPTIONS": [
-      "At the start of combat, #yslimeboundmod:Split into a #yslimeboundmod:Leeching #ySlime and gain #b1 Slime slot."
+      "At the start of combat, gain #b1 Slime slot and #yslimeboundmod:Split into a random #ySlime."
     ]
   },
   "Slimebound:SelfDamagePreventRelic": {


### PR DESCRIPTION
Slimeboss:
-Stone of Nomakk changed: now a common Relic, no loner Splits into a Mire Slime.
-Slimed Tail reworked: now reads "Whenever you Split, gain 3 Block."
-Jeremiah's Banner changed: now splits into a random Slime instead of Leeching one.

General:
-Deca's Washers changed: now reads "At the start of the first 3 turns of each combat, draw an additional card."
-Supply Relic reworked:  now a Rare Relic that reads "At the start of your 3rd turn, gain 1 Energy and draw 2 cards."
-Arumba's Pocket Sentry nerfed: now reads "Every 3 turns, apply 1 Weak to ALL enemies."
-Ethereal no longer can be applied to cards that Retain and vice versa.